### PR TITLE
Rename marshal_schemas to marshal_schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 1.0.0
+-------------
+
+* Renamed ``marshal_schemas`` parameter to ``marshal_schema``. While the marshal schema parameter is a bit more complex since it can also receive a dictionary, keeping it singular is more consistent with the other parameters. Note that this is a breaking change since 0.1.0.
+
 Version 0.1.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Example
        rule='/todos/<int:todo_id>',
        method='GET',
        query_string_schema=UpdateTodoSchema(),
-       marshal_schemas=TodoSchema(),
+       marshal_schema=TodoSchema(),
    )
    def get_todo(todo_id):
        """
@@ -75,7 +75,7 @@ Example
 
        ...
 
-       # The response will be marshaled by `marshal_schemas`
+       # The response will be marshaled by `marshal_schema`
        return {'data': {}}
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ Here's what a basic Flask-Rebar application looks like:
        rule='/todos/<int:todo_id>',
        method='GET',
        query_string_schema=UpdateTodoSchema(),
-       marshal_schemas=TodoSchema(),
+       marshal_schema=TodoSchema(),
    )
    def get_todo(todo_id):
        """
@@ -70,7 +70,7 @@ Here's what a basic Flask-Rebar application looks like:
 
        ...
 
-       # The response will be marshaled by `marshal_schemas`
+       # The response will be marshaled by `marshal_schema`
        return {'data': {}}
 
 

--- a/docs/quickstart/basics.rst
+++ b/docs/quickstart/basics.rst
@@ -25,7 +25,7 @@ Let's take a look at a very basic API using Flask-Rebar:
    @registry.handles(
       rule='/todos/<id>',
       method='GET',
-      marshal_schemas=TodoSchema()
+      marshal_schema=TodoSchema()
    )
    def get_todo(id):
        ...
@@ -47,7 +47,7 @@ We then create a handler registry that we will use to declare handlers for the s
 
 ``method`` is the HTTP method that the handler will accept. To register multiple methods for a single handler function, decorate the function multiple times.
 
-``marshal_schemas`` is a Marshmallow schema that will be used marshal the return value of the function. `marshmallow.Schema.dump <http://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.dump>`_ will be called on the return value. ``marshal_schemas`` can also be a dictionary mapping status codes to Marshmallow schemas - see :ref:`Marshaling`.
+``marshal_schema`` is a Marshmallow schema that will be used marshal the return value of the function. `marshmallow.Schema.dump <http://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.dump>`_ will be called on the return value. ``marshal_schema`` can also be a dictionary mapping status codes to Marshmallow schemas - see :ref:`Marshaling`.
 
 The handler function should accept any arguments specified in ``rule``, just like a Flask view function.
 
@@ -153,7 +153,7 @@ This default can be overriden in any particular handler by setting ``headers_sch
 Marshaling
 ==========
 
-The ``marshal_schemas`` argument of ``HandlerRegistry.handles`` can be one of three types: a ``marshmallow.Schema``, a dictionary mapping integers to ``marshmallow.Schema``, or ``None``.
+The ``marshal_schema`` argument of ``HandlerRegistry.handles`` can be one of three types: a ``marshmallow.Schema``, a dictionary mapping integers to ``marshmallow.Schema``, or ``None``.
 
 In the case of a ``marshmallow.Schema``, that schema is used to ``dump`` the return value of the handler function.
 
@@ -164,7 +164,7 @@ In the case of a dictionary mapping integers to ``marshmallow.Schemas``, the int
    @registry.handles(
       rule='/todos',
       method='POST',
-      marshal_schemas={
+      marshal_schema={
           201: TodoSchema()
       }
    )
@@ -174,7 +174,7 @@ In the case of a dictionary mapping integers to ``marshmallow.Schemas``, the int
 
 The schema to use for marshaling will be retrieved based on the status code the handler function returns. This isn't the prettiest part of Flask-Rebar, but it's done this way to help with the automatic Swagger generation.
 
-In the case of ``None`` (which is also the default), no marshaling takes place, and the return value is passed directly through to Flask. This means the if ``marshal_schemas`` is ``None``, the return value must be a return value that Flask supports, e.g. a string or a ``Flask.Response`` object.
+In the case of ``None`` (which is also the default), no marshaling takes place, and the return value is passed directly through to Flask. This means the if ``marshal_schema`` is ``None``, the return value must be a return value that Flask supports, e.g. a string or a ``Flask.Response`` object.
 
 .. code-block:: python
 
@@ -182,7 +182,7 @@ In the case of ``None`` (which is also the default), no marshaling takes place, 
    @registry.handles(
       rule='/todos',
       method='GET',
-      marshal_schemas=None
+      marshal_schema=None
    )
    def get_todos():
        ...

--- a/examples/todo/todo.py
+++ b/examples/todo/todo.py
@@ -60,7 +60,7 @@ class TodoListSchema(ResponseSchema):
 
     # This dictionary tells framer which schema to use for which response code.
     # This is a little ugly, but tremendously helpful for generating swagger.
-    marshal_schemas={
+    marshal_schema={
         201: TodoResourceSchema()
     }
 )
@@ -90,7 +90,7 @@ def create_todo():
 
     # If the value for this is not a dictionary, the response code is assumed
     # to be 200
-    marshal_schemas=TodoListSchema()
+    marshal_schema=TodoListSchema()
 )
 def get_todos():
     global todo_database
@@ -112,7 +112,7 @@ def get_todos():
 @registry.handles(
     rule='/todos/<int:todo_id>',
     method='PATCH',
-    marshal_schemas=TodoResourceSchema(),
+    marshal_schema=TodoResourceSchema(),
     request_body_schema=UpdateTodoSchema()
 )
 def update_todo(todo_id):

--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -495,8 +495,8 @@ class SwaggerV2Generator(object):
                     }
                 }
 
-                if d.marshal_schemas:
-                    for status_code, schema in d.marshal_schemas.items():
+                if d.marshal_schema:
+                    for status_code, schema in d.marshal_schema.items():
                         if schema is not None:
                             response_definition = {
                                 sw.description: _get_response_description(schema),
@@ -573,8 +573,8 @@ class SwaggerV2Generator(object):
         converted.append(self._response_converter(self.default_response_schema))
 
         for d in self._iterate_path_definitions(paths=paths):
-            if d.marshal_schemas:
-                for schema in d.marshal_schemas.values():
+            if d.marshal_schema:
+                for schema in d.marshal_schema.values():
                     if schema is None:
                         # Responses that don't have a response body have None
                         # for a schema

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -171,7 +171,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
         @registry.handles(
             rule='/foos/<uuid_string:foo_uid>',
             method='GET',
-            marshal_schemas={200: FooSchema()},
+            marshal_schema={200: FooSchema()},
             headers_schema=HeaderSchema()
         )
         def get_foo(foo_uid):
@@ -181,7 +181,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
         @registry.handles(
             rule='/foos/<foo_uid>',
             method='PATCH',
-            marshal_schemas={200: FooSchema()},
+            marshal_schema={200: FooSchema()},
             request_body_schema=FooUpdateSchema(),
             authenticator=authenticator
         )
@@ -191,7 +191,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
         @registry.handles(
             rule='/foos',
             method='GET',
-            marshal_schemas={200: ListOfFooSchema()},
+            marshal_schema={200: ListOfFooSchema()},
             query_string_schema=FooListSchema(),
             authenticator=None  # Override the default!
         )

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -90,7 +90,7 @@ def register_endpoint(
         path='/foos/<foo_uid>',
         method='GET',
         endpoint=None,
-        marshal_schemas=None,
+        marshal_schema=None,
         query_string_schema=None,
         request_body_schema=None,
         headers_schema=None,
@@ -104,7 +104,7 @@ def register_endpoint(
         rule=path,
         method=method,
         endpoint=endpoint,
-        marshal_schemas=marshal_schemas or {200: FooSchema()},
+        marshal_schema=marshal_schema or {200: FooSchema()},
         query_string_schema=query_string_schema,
         request_body_schema=request_body_schema,
         headers_schema=headers_schema,
@@ -179,7 +179,7 @@ class RebarTest(unittest.TestCase):
         @registry.handles(
             rule='/foos/<foo_uid>',
             method='PATCH',
-            marshal_schemas={
+            marshal_schema={
                 200: FooSchema()
             },
             request_body_schema=FooUpdateSchema(),
@@ -214,7 +214,7 @@ class RebarTest(unittest.TestCase):
         @registry.handles(
             rule='/foos',
             method='GET',
-            marshal_schemas={
+            marshal_schema={
                 200: ListOfFooSchema()
             },
             query_string_schema=FooListSchema(),
@@ -246,7 +246,7 @@ class RebarTest(unittest.TestCase):
         @registry.handles(
             rule='/me',
             method='GET',
-            marshal_schemas={
+            marshal_schema={
                 200: MeSchema(),
             },
             headers_schema=HeadersSchema()
@@ -303,7 +303,7 @@ class RebarTest(unittest.TestCase):
 
         common_kwargs = {
             'method': 'GET',
-            'marshal_schemas': {200: FooSchema()},
+            'marshal_schema': {200: FooSchema()},
         }
 
         @registry.handles(rule='/bars/<foo_uid>', endpoint='bar', **common_kwargs)
@@ -330,7 +330,7 @@ class RebarTest(unittest.TestCase):
 
         common_kwargs = {
             'rule': '/foos/<foo_uid>',
-            'marshal_schemas': {200: FooSchema()},
+            'marshal_schema': {200: FooSchema()},
         }
 
         @registry.handles(method='GET', endpoint='get_foo', **common_kwargs)
@@ -362,7 +362,7 @@ class RebarTest(unittest.TestCase):
         @registry.handles(
             rule='/me',
             method='GET',
-            marshal_schemas=MeSchema()
+            marshal_schema=MeSchema()
         )
         def get_me():
             return {
@@ -372,7 +372,7 @@ class RebarTest(unittest.TestCase):
         @registry.handles(
             rule='/myself',
             method='GET',
-            marshal_schemas=MeSchema(),
+            marshal_schema=MeSchema(),
 
             # Let's make sure this can be overridden
             headers_schema=None


### PR DESCRIPTION
This one has me a bit torn, since its a breaking change. But I think the initial choice to make this plural was incorrect. I worry that it will make it tricky for newcomers since its slightly different from the other parameters, _especially_ if they don't have a fancy IDE that can do code completion.