### PR TITLE
Pass flask Response objects straight through if returned by view functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ man/
 
 # pytest
 .pytest_cache
+
+# pyenv
+.python-version
+
+# ctags
+tags


### PR DESCRIPTION
The test shows how this can be used to, say, override default Flask/werkzeug/rebar processing. Sometimes you just to control what gets returned, you know?