### PR TITLE
Changed default 'produces' of swagger generation to 'application/json'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+NEXT RELEASE
+------------
+
+* Changed default "produces" of swagger generation to "application/json".
+
 Version 1.0.0
 -------------
 

--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -275,7 +275,7 @@ class SwaggerV2Generator(object):
             host='swag.com',
             schemes=('http',),
             consumes=('application/json',),
-            produces=('application/vnd.plangrid+json',),
+            produces=('application/json',),
             version='1.0.0',
             title='My API',
             description='',


### PR DESCRIPTION
This addresses https://github.com/plangrid/flask-rebar/issues/17