### PR TITLE
Add tests to twosigmajab patch1

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -19,9 +19,7 @@ from functools import wraps
 
 import marshmallow
 from flask import __version__ as flask_version
-from flask import current_app, jsonify
-from flask import g
-from flask import request
+from flask import current_app, g, jsonify, make_response, request
 from werkzeug.routing import RequestRedirect
 
 from flask_rebar import messages
@@ -94,36 +92,30 @@ def _wrap_handler(
 
         rv = f(*args, **kwargs)
 
-        if marshal_schema:
-            if isinstance(rv, tuple):
-                data, status_code = rv[0], rv[1]
-            else:
-                data, status_code = rv, 200
-
-            try:
-                schema = marshal_schema[status_code]
-            except KeyError:
-                raise
-
-            if schema is None:
-                # Allow for the schema to be declared as None, which allows
-                # for status codes with no bodies (i.e. a 204 status code)
-                return response(
-                    data=data, status_code=status_code
-                )
-
-            marshaled = marshal(
-                data=data,
-                schema=schema
-            )
-
-            return response(
-                data=marshaled,
-                status_code=status_code
-            )
-
-        else:
+        if not marshal_schema:
             return rv
+
+        data, status_code, headers = rv, 200, None
+        if isinstance(rv, tuple):
+            data = rv[0]
+            if len(rv) == 2:
+                if isinstance(rv[1], (int, str)):
+                    status_code = int(rv[1])
+                else:
+                    headers = rv[1]
+            elif len(rv) == 3:
+                status_code, headers = rv[1:3]
+                status_code = int(status_code)
+            else:
+                raise ValueError(rv)
+
+        schema = marshal_schema[status_code]  # May raise KeyError.
+        # The schema may be declared as None to bypass marshaling (e.g. for 204 responses).
+        if schema is None:
+            return make_response((data or '', status_code, headers))
+
+        marshaled = marshal(data=data, schema=schema)
+        return response(data=marshaled, status_code=status_code, headers=headers)
 
     return wrapped
 

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -20,6 +20,7 @@ from functools import wraps
 import marshmallow
 from flask import __version__ as flask_version
 from flask import current_app, g, jsonify, make_response, request
+from werkzeug.datastructures import Headers
 from werkzeug.routing import RequestRedirect
 
 from flask_rebar import messages
@@ -54,6 +55,38 @@ if LooseVersion(flask_version) < LooseVersion('0.11.0'):
     REDIRECT_ERROR = 301
 else:
     REDIRECT_ERROR = RequestRedirect
+
+
+def _unpack_view_func_return_value(rv):
+    """
+    Normalize a return value from a view function into a tuple of (body, status, headers).
+
+    This imitates Flask's own `Flask.make_response` method.
+
+    :param Optional[tuple] rv: (body, status, headers), (body, status), or (body, headers)
+    :return: (body, status, headers)
+    :rtype: tuple
+    """
+    data, status, headers = rv, 200, None
+
+    if isinstance(rv, tuple):
+        len_rv = len(rv)
+
+        if len_rv == 3:
+            data, status, headers = rv
+        elif len_rv == 2:
+            if isinstance(rv[1], (Headers, dict, tuple, list)):
+                data, headers = rv
+            else:
+                data, status = rv
+        else:
+            raise TypeError(
+                'The view function did not return a valid response tuple.'
+                ' The tuple must have the form (body, status, headers),'
+                ' (body, status), or (body, headers).'
+            )
+
+    return data, int(status), headers
 
 
 def _wrap_handler(
@@ -95,21 +128,10 @@ def _wrap_handler(
         if not marshal_schema:
             return rv
 
-        data, status_code, headers = rv, 200, None
-        if isinstance(rv, tuple):
-            data = rv[0]
-            if len(rv) == 2:
-                if isinstance(rv[1], (int, str)):
-                    status_code = int(rv[1])
-                else:
-                    headers = rv[1]
-            elif len(rv) == 3:
-                status_code, headers = rv[1:3]
-                status_code = int(status_code)
-            else:
-                raise ValueError(rv)
+        data, status_code, headers = _unpack_view_func_return_value(rv)
 
         schema = marshal_schema[status_code]  # May raise KeyError.
+
         # The schema may be declared as None to bypass marshaling (e.g. for 204 responses).
         if schema is None:
             return make_response((data or '', status_code, headers))

--- a/flask_rebar/request_utils.py
+++ b/flask_rebar/request_utils.py
@@ -20,9 +20,9 @@ from flask_rebar import messages
 from flask_rebar import errors
 
 
-def response(data, status_code=200):
+def response(data, status_code=200, headers=None):
     """
-    Constructs a flask.Response.
+    Constructs a flask.jsonify response.
 
     :param dict data: The JSON body of the response
     :param int status_code: HTTP status code to use in the response
@@ -30,6 +30,7 @@ def response(data, status_code=200):
     """
     resp = jsonify(data)
     resp.status_code = status_code
+    resp.headers.extend(headers or {})
     return resp
 
 

--- a/tests/test_request_utils.py
+++ b/tests/test_request_utils.py
@@ -43,6 +43,19 @@ class TestResponseFormatting(TestCase):
         self.assertEqual(resp.json, {'foo': 'bar'})
         self.assertEqual(resp.content_type, 'application/json')
 
+    def test_single_resource_response_with_headers(self):
+        header_key = 'X-Foo'
+        header_value = 'bar'
+
+        @self.app.route('/single_resource')
+        def handler():
+            return response(data={'foo': 'bar'}, headers={header_key: header_value})
+
+        resp = self.app.test_client().get('/single_resource')
+        self.assertEqual(resp.headers[header_key], header_value)
+        self.assertEqual(resp.json, {'foo': 'bar'})
+        self.assertEqual(resp.content_type, 'application/json')
+
 
 class SchemaForMarshaling(validation.ResponseSchema):
     foo = fields.Integer()


### PR DESCRIPTION
Extending this PR - https://github.com/plangrid/flask-rebar/pull/26 - with tests. 

And as @twosigmajab recommends, I made the tuple unpacking logic match Flask's more closely. I opted to not call Flask's `Flask.make_response` method directly, since I think it has slightly different intentions.