### PR TITLE
Update release docs.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,7 +51,7 @@ Flask-Rebar uses `semantic versions <https://semver.org/>`_. Once you know the a
 .. code-block:: bash
 
    git checkout master
-   bumpversion MINOR
+   bumpversion minor
 
 Then push the new commit and tags to master:
 


### PR DESCRIPTION
The versions that `bumpversion` accepts are actually all lower case. If you try to do `bumpversion PATCH` you'll see an error like:
```
Traceback (most recent call last):
  File "/Users/jalexander/.virtualenvs/flask-rebar/bin/bumpversion", line 11, in <module>
    sys.exit(main())
  File "/Users/jalexander/.virtualenvs/flask-rebar/lib/python3.6/site-packages/bumpversion/__init__.py", line 994, in main
    vcs.commit(message=commit_message)
  File "/Users/jalexander/.virtualenvs/flask-rebar/lib/python3.6/site-packages/bumpversion/__init__.py", line 73, in commit
    list(os.environ.items()) + [(b'HGENCODING', b'utf-8')]
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'commit', '-F', '/var/folders/8m/zmzdhqtd139g5k2_nxf6hmh92lylxp/T/tmpq6mphc3n']' returned non-zero exit status 1.
```