### PR TITLE
Sort query params for consistent output

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -172,7 +172,7 @@ def _convert_jsonschema_to_list_of_parameters(obj, in_='query'):
 
     required = obj.get('required', [])
 
-    for name, prop in obj['properties'].items():
+    for name, prop in sorted(obj['properties'].items(), key=lambda i: i[0]):
         parameter = copy.deepcopy(prop)
         parameter['required'] = name in required
         parameter['in'] = in_

--- a/flask_rebar/testing/__init__.py
+++ b/flask_rebar/testing/__init__.py
@@ -1,5 +1,5 @@
 import jsonschema
-from flask_rebar.testing. swagger_jsonschema import SWAGGER_V2_JSONSCHEMA
+from flask_rebar.testing.swagger_jsonschema import SWAGGER_V2_JSONSCHEMA
 
 
 def validate_swagger(swagger, schema=SWAGGER_V2_JSONSCHEMA):

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -167,6 +167,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
 
         class FooListSchema(m.Schema):
             name = m.fields.String()
+            other = m.fields.String()
 
         @registry.handles(
             rule='/foos/<uuid_string:foo_uid>',
@@ -321,7 +322,13 @@ class TestSwaggerV2Generator(unittest.TestCase):
                                 'in': 'query',
                                 'required': False,
                                 'type': 'string'
-                            }
+                            },
+                            {
+                                'name': 'other',
+                                'in': 'query',
+                                'required': False,
+                                'type': 'string'
+                            },
                         ],
                         'security': []
                     }
@@ -368,6 +375,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
 
         # import json
         # print(json.dumps(swagger, indent=2))
+        # print(json.dumps(expected_swagger, indent=2))
         # self.assertTrue(False)
 
         # This will raise an error if validation fails


### PR DESCRIPTION
Query params e.g. `skip`, `limit` are not sorted, so show up swapped in clients, leading to a lot of verbose non-changes in the generated clients. Adding a sort on them to keep client diffs clean. 

cc: @barakalon 