### PR TITLE
rm superfluous logic in swagger_ui.blueprint.show

### DIFF
--- a/flask_rebar/swagger_ui/blueprint.py
+++ b/flask_rebar/swagger_ui/blueprint.py
@@ -47,14 +47,7 @@ def create_swagger_ui_blueprint(
     }
 
     @blueprint.route('/')
-    @blueprint.route('/<path:path>')
-    def show(path=None):
-        if not path or path == 'index.html':
-            return render_template(
-                'index.html.jinja2',
-                **template_context
-            )
-        else:
-            return current_app.send_static_file(path)
+    def show():
+        return render_template('index.html.jinja2', **template_context)
 
     return blueprint


### PR DESCRIPTION
I'm not sure the current logic in the swagger_ui blueprint's `show()` handler makes sense.

Currently it's trying to manually call `send_static_file` for all paths except / and /index.html, but I don't think this is actually useful or getting used. Why not just let Flask handle this automatically for the configured static path, which is the route that is already getting used for requests like `/swagger/ui/static/swagger-ui.css` anyway?

I tested the Swagger UI with these changes and it worked like a charm. (The automated test suite also passed.)