### PR TITLE
Respect many=True in swagger_generator.

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -504,7 +504,7 @@ class SwaggerV2Generator(object):
                         if schema is not None:
                             response_definition = {
                                 sw.description: _get_response_description(schema),
-                                sw.schema: {sw.ref: _get_ref(get_swagger_title(schema))}
+                                sw.schema: self._get_schema(schema),
                             }
 
                             responses_definition[str(status_code)] = response_definition
@@ -530,7 +530,7 @@ class SwaggerV2Generator(object):
                         sw.name: schema.__class__.__name__,
                         sw.in_: sw.body,
                         sw.required: True,
-                        sw.schema: {sw.ref: _get_ref(get_swagger_title(schema))}
+                        sw.schema: self._get_schema(schema),
                     })
 
                 if d.headers_schema is USE_DEFAULT and default_headers_schema:
@@ -567,6 +567,10 @@ class SwaggerV2Generator(object):
                     path_definition[method_lower][sw.security] = security
 
         return path_definitions
+
+    def _get_schema(self, schema):
+        ref = {sw.ref: _get_ref(get_swagger_title(schema))}
+        return ref if not schema.many else {sw.type_: sw.array, sw.items: ref}
 
     def _get_definitions(self, paths):
         all_schemas = set()

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -157,7 +157,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
             uid = m.fields.String()
             name = m.fields.String()
 
-        class ListOfFooSchema(m.Schema):
+        class NestedFoosSchema(m.Schema):
             data = m.fields.Nested(FooSchema, many=True)
 
         class FooUpdateSchema(m.Schema):
@@ -165,7 +165,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
 
             name = m.fields.String()
 
-        class FooListSchema(m.Schema):
+        class NameAndOtherSchema(m.Schema):
             name = m.fields.String()
             other = m.fields.String()
 
@@ -189,14 +189,25 @@ class TestSwaggerV2Generator(unittest.TestCase):
         def update_foo(foo_uid):
             pass
 
+        # Test using Schema(many=True) without using a nested Field.
+        # https://github.com/plangrid/flask-rebar/issues/41
         @registry.handles(
-            rule='/foos',
+            rule='/foo_list',
             method='GET',
-            marshal_schema={200: ListOfFooSchema()},
-            query_string_schema=FooListSchema(),
+            marshal_schema={200: FooSchema(many=True)},
             authenticator=None  # Override the default!
         )
         def list_foos():
+            pass
+
+        @registry.handles(
+            rule='/foos',
+            method='GET',
+            marshal_schema={200: NestedFoosSchema()},
+            query_string_schema=NameAndOtherSchema(),
+            authenticator=None  # Override the default!
+        )
+        def nested_foos():
             pass
 
         registry.set_default_authenticator(default_authenticator)
@@ -204,7 +215,7 @@ class TestSwaggerV2Generator(unittest.TestCase):
         host = 'swag.com'
         schemes = ['http']
         consumes = ['application/json']
-        produces = ['application/vnd.plangrid+json']
+        produces = ['application/json']
         title = 'Test API'
         version = '2.1.0'
 
@@ -303,13 +314,32 @@ class TestSwaggerV2Generator(unittest.TestCase):
                         'security': [{'sharedSecret': []}]
                     }
                 },
-                '/foos': {
+                '/foo_list': {
                     'get': {
                         'operationId': 'list_foos',
                         'responses': {
                             '200': {
-                                'description': 'ListOfFooSchema',
-                                'schema': {'$ref': '#/definitions/ListOfFooSchema'}
+                                'description': 'Foo',
+                                'schema': {
+                                    'type': 'array',
+                                    'items': {'$ref': '#/definitions/Foo'}
+                                },
+                            },
+                            'default': {
+                                'description': 'Error',
+                                'schema': {'$ref': '#/definitions/Error'}
+                            }
+                        },
+                        'security': []
+                    }
+                },
+                '/foos': {
+                    'get': {
+                        'operationId': 'nested_foos',
+                        'responses': {
+                            '200': {
+                                'description': 'NestedFoosSchema',
+                                'schema': {'$ref': '#/definitions/NestedFoosSchema'}
                             },
                             'default': {
                                 'description': 'Error',
@@ -350,9 +380,9 @@ class TestSwaggerV2Generator(unittest.TestCase):
                         'name': {'type': 'string'}
                     }
                 },
-                'ListOfFooSchema': {
+                'NestedFoosSchema': {
                     'type': 'object',
-                    'title': 'ListOfFooSchema',
+                    'title': 'NestedFoosSchema',
                     'properties': {
                         'data': {
                             'type': 'array',


### PR DESCRIPTION
Fixes #41.

With these changes, the spec for the example handler from #41 now correctly documents an array of Foos instead of a single Foo:

![screen shot 2018-11-28 at 12 22 13](https://user-images.githubusercontent.com/40300730/49169733-7c918680-f308-11e8-9aa0-76dfd08d4570.png)

```json
{
  "consumes": [
    "application/json"
  ], 
  "definitions": {
    "Error": {
      "properties": {
        "errors": {
          "type": "object"
        }, 
        "message": {
          "type": "string"
        }
      }, 
      "required": [
        "message"
      ], 
      "title": "Error", 
      "type": "object"
    }, 
    "Foo": {
      "properties": {
        "foo": {
          "type": "string"
        }
      }, 
      "required": [
        "foo"
      ], 
      "title": "Foo", 
      "type": "object"
    }
  }, 
  "host": "localhost:5000", 
  "info": {
    "description": "", 
    "title": "My API", 
    "version": "1.0.0"
  }, 
  "paths": {
    "/foos/": {
      "get": {
        "operationId": "get_foos", 
        "responses": {
          "200": {
            "description": "Foo", 
            "schema": {
              "items": {
                "$ref": "#/definitions/Foo"
              }, 
              "type": "array"
            }
          }, 
          "default": {
            "description": "Error", 
            "schema": {
              "$ref": "#/definitions/Error"
            }
          }
        }
      }
    }
  }, 
  "produces": [
    "application/json"
  ], 
  "schemes": [
    "http"
  ], 
  "securityDefinitions": {}, 
  "swagger": "2.0"
}
```
