### PR TITLE
Support setting response content-types for endpoints.

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -554,6 +554,9 @@ class SwaggerV2Generator(object):
                     sw.responses: responses_definition
                 }
 
+                if d.produces is not USE_DEFAULT and d.produces is not None:
+                    path_definition[method_lower][sw.produces] = d.produces
+
                 if d.func.__doc__:
                     path_definition[method_lower][sw.description] = d.func.__doc__
 

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -214,6 +214,15 @@ class TestSwaggerV2Generator(unittest.TestCase):
         def nested_foos():
             pass
 
+        @registry.handles(
+            rule='/xml',
+            method='GET',
+            marshal_schema={200: FooSchema()},
+            produces=['text/xml']
+        )
+        def get_xml(foo_uid):
+            pass
+
         registry.set_default_authenticator(default_authenticator)
 
         host = 'swag.com'
@@ -365,6 +374,22 @@ class TestSwaggerV2Generator(unittest.TestCase):
                             },
                         ],
                         'security': []
+                    }
+                },
+                '/xml': {
+                    'get': {
+                        'operationId': 'get_xml',
+                        'produces': ['text/xml'],
+                        'responses': {
+                            '200': {
+                                'description': 'Foo',
+                                'schema': {'$ref': '#/definitions/Foo'}
+                            },
+                            'default': {
+                                'description': 'Error',
+                                'schema': {'$ref': '#/definitions/Error'}
+                            }
+                        }
                     }
                 }
             },


### PR DESCRIPTION
WIP. Currently it only hooks up the registry to the swagger so you can define the response type for a specific endpoint. We probably want to only allow certain content types here because I think we need special ways to "dump" things based on what content type it's supposed to be.