### PR TITLE
Add 'https' to default schemes

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -273,7 +273,7 @@ class SwaggerV2Generator(object):
     def __init__(
             self,
             host='swag.com',
-            schemes=('http',),
+            schemes=('http', 'https'),
             consumes=('application/json',),
             produces=('application/json',),
             version='1.0.0',


### PR DESCRIPTION
Flask-Rebar currently sets `schemes` to `('http',)` by default. As a result, users serving their app over HTTPS get broken "Try it out" buttons in their Swagger UI out of the box (because for security reasons the browser will refuse to make the XHRs over HTTP). To get around this, users have to manually add code like the following:
```python
registry.swagger_generator.schemes = ('http', 'https')
```
Now they will be able to select "https" from the "schemes" dropdown in the Swagger UI and the "Try it out" buttons will work.

What do you think of defaulting to `('http', 'https')` out of the box?