### PR TITLE
Change schemes=() default so Swagger UI infers scheme from document URL

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -307,7 +307,9 @@ class SwaggerV2Generator(object):
         static specification that will be used across multiple hosts (i.e.
         PlanGrid folks, don't worry about this guy. We have to override it
         manually when initializing a client anyways.
-    :param Sequence[str] schemes: "http", "https", "ws", or "wss"
+    :param Sequence[str] schemes: "http", "https", "ws", or "wss".
+        Defaults to empty. If left empty, the Swagger UI will infer the scheme
+        from the document URL, ensuring that the "Try it out" buttons work.
     :param Sequence[str] consumes: Mime Types the API accepts
     :param Sequence[str] produces: Mime Types the API returns
 
@@ -325,7 +327,7 @@ class SwaggerV2Generator(object):
     def __init__(
             self,
             host='swag.com',
-            schemes=('http', 'https'),
+            schemes=(),
             consumes=('application/json',),
             produces=('application/json',),
             version='1.0.0',


### PR DESCRIPTION
Apologies that I previously misunderstood https://github.com/swagger-api/swagger-ui/issues/4710#issuecomment-405448739 in https://github.com/plangrid/flask-rebar/pull/53#issuecomment-452852463 (see below):

This avoids frequently seen issues where Swagger UI's "Try it out"
buttons don't work due to browsers' mixed content protections.
Specifically, when `schemes` is left set to its previous default of
("http", "https"), Swagger UI will set the "schemes" dropdown to "http"
since it is the first value in the sequence, even when the page has been
loaded (and the service is only available) over HTTPS. This causes
Swagger UI's "Try it out" buttons to trigger javascript-initiated API
call attempts over HTTP, which browsers will block due to mixed content
protections, resulting in a vague failure message in the Swagger UI that
doesn't explain what went wrong. Users often don't realize they must
manually change the "schemes" dropdown to "https" to get this to work.
Setting schemes=() by default causes Swagger UI to infer the correct
scheme from the document URL, such that the "Try it out" buttons always
work whether the application is being served over HTTP or HTTPS. This
also causes Swagger UI to hide the "schemes" dropdown.

Users can and should still explicitly set `schemes` based on the
scheme(s) that their services actually support, but if they don't, this
provides a more usable default given the interaction with Swagger UI.

For the future we could consider other improvements such as:
- Submitting a PR to Swagger UI so that when the "schemes" dropdown contains multiple choices, rather than defaulting to the first one, default to the one that matches the document URL
- Submitting a PR to Swagger UI to detect and warn about mixed content configurations and automatically override `scheme` to match the document URL, rather than ever even trying to make mixed content requests that it should know the browser will block
- Have `rebar.init_app` set the `schemes` default value to `(app.config['PREFERRED_URL_SCHEME'],)` rather than leaving it empty

 JIRA Tickets | 
 --------------| 
 [ISSUECOMMENT-405448739](https://plangrid.atlassian.net/browse/ISSUECOMMENT-405448739)|
