### PR TITLE
Add recipe for class based views

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,5 +98,6 @@ Here's what a basic Flask-Rebar application looks like:
    quickstart/swagger_generation
    quickstart/authentication
    api_reference
+   recipes
    contributing
    changelog

--- a/docs/quickstart/swagger_generation.rst
+++ b/docs/quickstart/swagger_generation.rst
@@ -120,7 +120,6 @@ The method should take two arguments in addition to ``self``: ``obj`` and ``cont
 ``context`` is a namedtuple that holds some helpful information for more complex conversions:
 
 * ``convert`` - This will hold a reference to a convert method that can be used to make recursive calls
-* ``direction`` - This will be either IN or OUT, and signifies if the converter should treat the marshmallow schema as "load"ing or "dump"ing. This helps to handle things like ``load_from`` and ``dump_to`` on a Marshmallow field.
 * ``memo`` - This holds the JSONSchema object that's been converted so far. This helps convert Validators, which might depend on the type of the object they are validating.
 * ``schema`` - This is the full schema being converted (as opposes to ``obj``, which might be a specific field in the schema).
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -1,0 +1,62 @@
+Recipes
+-------
+
+Class Based Views
+=================
+
+Some people prefer basing Flask view functions on classes rather than functions, and other REST frameworks for Flask base themselves on classes.
+
+First, an opinion: people often prefer classes simply because they are used to them. If you're looking for classes because functions make you uncomfortable, I encourage you to take a moment to reconsider your feelings. Embracing functions, `thread locals <http://flask.pocoo.org/docs/1.0/design/#thread-locals>`_, and all of Flask's little quirks can feel oh so good.
+
+With that, there are perfectly valid use cases for class based views, like creating abstract views that can be inherited and customized. This is the main intent of Flask's built-in `pluggable views <http://flask.pocoo.org/docs/latest/views/>`_.
+
+Here is a simple recipe for using Flask-Rebar with these pluggable views:
+
+
+.. code-block:: python
+
+   from flask import Flask
+   from flask import request
+   from flask.views import MethodView
+   from flask_rebar import Rebar
+
+
+   rebar = Rebar()
+   registry = rebar.create_handler_registry()
+
+
+   class AbstractResource(MethodView):
+       def __init__(self, database):
+           self.database = database
+
+       def get_resource(self, id):
+           raise NotImplemented
+
+       def get(self, id):
+           return self.get_resource(id)
+
+       def put(self, id):
+           resource = self.get_resource(id)
+           resource.update(rebar.validated_body)
+           return resource
+
+
+   class Todo(AbstractResource):
+       def get_resource(self, id):
+           return get_todo(database, id)
+
+
+   for method, request_body_schema in [
+       ("get", None),
+       ("put", UpdateTodoSchema()),
+   ]:
+       registry.add_handler(
+           func=Todo.as_view(method + "_todo", database=database),
+           rule="/todos/<id>",
+           marshal_schema=TodoSchema(),
+           method=method,
+           request_body_schema=request_body_schema,
+       )
+
+
+This isn't a super slick, classed based interface for Flask-Rebar, but it *is* a way to use unadulterated Flask views to their full intent with minimal `DRY <https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>`_ violations.


### PR DESCRIPTION
In response to https://github.com/plangrid/flask-rebar/issues/11

After playing with this for a while, I think it's best to leave explicit class based views out of Flask-Rebar. I just don't think they have much utility, and in my experience they end up making code more complex than it needs to be. I'd be interested in hearing other opinions!

We could add a helper function, maybe called `register_view`, that essentially does what the `for` loop is doing in this recipe. But the interface is a little tricky to get right. Again, happy to hear thoughts.
