### PR TITLE
Add swagger mapping for oid_string

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator.py
+++ b/flask_rebar/swagger_generation/swagger_generator.py
@@ -376,6 +376,7 @@ class SwaggerV2Generator(object):
         self.flask_converters_to_swagger_types = {
             "uuid": sw.string,
             "uuid_string": sw.string,
+            "oid_string": sw.string,
             "string": sw.string,
             "path": sw.string,
             "int": sw.integer,


### PR DESCRIPTION
Add a mapping for a Flask converter of type oid_string to Swagger's
string type.