### PR TITLE
sort required array

### DIFF
--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -199,7 +199,9 @@ class SchemaConverter(MarshmallowConverter):
                 prop = compat.get_data_key(field)
                 required.append(prop)
 
-        return sorted(required) if required else UNSET
+        if required and not obj.ordered:
+            required = sorted(required)
+        return required if required else UNSET
 
     @sets_swagger_attr(sw.description)
     def get_description(self, obj, context):

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -199,7 +199,7 @@ class SchemaConverter(MarshmallowConverter):
                 prop = compat.get_data_key(field)
                 required.append(prop)
 
-        return required if required else UNSET
+        return sorted(required) if required else UNSET
 
     @sets_swagger_attr(sw.description)
     def get_description(self, obj, context):

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -176,7 +176,7 @@ class TestConverterRegistry(unittest.TestCase):
 
         schema = Foo()
         json_schema = registry.convert(schema)
-        print(json_schema)
+
         self.assertEqual(
             json_schema,
             {

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -189,6 +189,7 @@ class TestConverterRegistry(unittest.TestCase):
 
     def test_required(self):
         class Foo(m.Schema):
+            b = m.fields.Integer(required=True)
             a = m.fields.Integer(required=True)
 
         schema = Foo()
@@ -199,8 +200,8 @@ class TestConverterRegistry(unittest.TestCase):
             {
                 "type": "object",
                 "title": "Foo",
-                "properties": {"a": {"type": "integer"}},
-                "required": ["a"],
+                "properties": {"b": {"type": "integer"}, "a": {"type": "integer"}},
+                "required": ["a", "b"],
             },
         )
 

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -176,7 +176,7 @@ class TestConverterRegistry(unittest.TestCase):
 
         schema = Foo()
         json_schema = registry.convert(schema)
-
+        print(json_schema)
         self.assertEqual(
             json_schema,
             {
@@ -191,6 +191,7 @@ class TestConverterRegistry(unittest.TestCase):
         class Foo(m.Schema):
             b = m.fields.Integer(required=True)
             a = m.fields.Integer(required=True)
+            c = m.fields.Integer()
 
         schema = Foo()
         json_schema = self.registry.convert(schema)
@@ -200,8 +201,38 @@ class TestConverterRegistry(unittest.TestCase):
             {
                 "type": "object",
                 "title": "Foo",
-                "properties": {"b": {"type": "integer"}, "a": {"type": "integer"}},
+                "properties": {
+                    "b": {"type": "integer"},
+                    "a": {"type": "integer"},
+                    "c": {"type": "integer"},
+                },
                 "required": ["a", "b"],
+            },
+        )
+
+    def test_ordered_required(self):
+        class Foo(m.Schema):
+            b = m.fields.Integer(required=True)
+            a = m.fields.Integer(required=True)
+            c = m.fields.Integer()
+
+            class Meta:
+                ordered = True
+
+        schema = Foo()
+        json_schema = self.registry.convert(schema)
+
+        self.assertEqual(
+            json_schema,
+            {
+                "type": "object",
+                "title": "Foo",
+                "properties": {
+                    "b": {"type": "integer"},
+                    "a": {"type": "integer"},
+                    "c": {"type": "integer"},
+                },
+                "required": ["b", "a"],
             },
         )
 


### PR DESCRIPTION
I believe ` obj.fields.items():` does not consistently return objects in the same order. When committing the generated `swagger.json` file, it causes some redundant diffs in the `required` fields array 

e.g: https://github.com/plangrid/informant/pull/419 