### PR TITLE
Fix #96 - Flask no longer treats redirects as errors

### DIFF
--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -610,11 +610,9 @@ class RebarTest(unittest.TestCase):
         app.debug = False
         resp = app.test_client().get(path="/with_trailing_slash")
         self.assertIn(resp.status_code, (301, 308))
-        self.assertEqual(resp.content_type, "application/json")
         self.assertTrue(resp.headers["Location"].endswith("/with_trailing_slash/"))
 
         app.debug = True
         resp = app.test_client().get(path="/with_trailing_slash")
         self.assertIn(resp.status_code, (301, 308))
-        self.assertEqual(resp.content_type, "application/json")
         self.assertTrue(resp.headers["Location"].endswith("/with_trailing_slash/"))


### PR DESCRIPTION
After investigating this, it seems the only way we could force this test to pass would be to fiddle with internals of Flask.  This seems like something we ought not do; instead just updating the test to ensure that it still returns the appropriate return code and expected redirect header (which *should* be all an app needs to process correctly)