### PR TITLE
fixes a bug where http 400s are returned as http 500s

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -656,6 +656,7 @@ class Rebar(object):
                 additional_data=error.additional_data,
             )
 
+        @app.errorhandler(400)
         @app.errorhandler(404)
         @app.errorhandler(405)
         def handle_werkzeug_http_error(error):


### PR DESCRIPTION
this is for a case where a werkzeug badrequest exception is raised
before the rebar handlers get invoked. this was causing the
default rebar exception handler to run, thus returning a 500