### PR TITLE
chg: Allow /swagger/ui to resolve to swagger UI without redirect

### DIFF
--- a/flask_rebar/swagger_ui/blueprint.py
+++ b/flask_rebar/swagger_ui/blueprint.py
@@ -44,6 +44,7 @@ def create_swagger_ui_blueprint(
     }
 
     @blueprint.route("/")
+    @blueprint.route("")
     def show():
         return render_template("index.html.jinja2", **template_context)
 

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -400,7 +400,14 @@ class RebarTest(unittest.TestCase):
         app = create_rebar_app(rebar)
 
         resp = app.test_client().get("/swagger/ui/")
+        self.assertEqual(resp.status_code, 200)
 
+    def test_swagger_ui_without_trailing_slash(self):
+        rebar = Rebar()
+        rebar.create_handler_registry()
+        app = create_rebar_app(rebar)
+
+        resp = app.test_client().get("/swagger/ui")
         self.assertEqual(resp.status_code, 200)
 
     def test_swagger_can_be_set_to_v3(self):


### PR DESCRIPTION
Previously `/swagger/ui` would 500 because of werkzeug's weird redirect behavior.