### PR TITLE
Deprecation util cleaned up and expanded a bit

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@ Changelog
 =========
 
 
-(unreleased)
-------------
+v1.8.1 (2019-06-14)
+-------------------
 
 Changes
 ~~~~~~~
@@ -12,6 +12,7 @@ Changes
 Fix
 ~~~
 - Bug in v1.8.0 deprecation util - deepcopy inadvertently replacing things like default_authenticator
+
 
 v1.8.0 (2019-06-12)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@ Changelog
 =========
 
 
+(unreleased)
+------------
+
+Changes
+~~~~~~~
+- Deprecation util cleaned up and expanded a bit. More forgiving of unexpected inputs. [Rick Riensche]
+
+Fix
+~~~
+- Bug in v1.8.0 deprecation util - deepcopy inadvertently replacing things like default_authenticator
+
 v1.8.0 (2019-06-12)
 -------------------
 

--- a/flask_rebar/utils/deprecation.py
+++ b/flask_rebar/utils/deprecation.py
@@ -8,7 +8,6 @@
     :license: MIT, see LICENSE for details.
 """
 
-import copy
 import functools
 import warnings
 from collections import namedtuple
@@ -123,7 +122,7 @@ def _remap_kwargs(func_name, kwargs, aliases):
     """
     Adapted from https://stackoverflow.com/a/49802489/977046
     """
-    remapped_args = copy.deepcopy(kwargs)
+    remapped_args = dict(kwargs)
     for alias, new_spec in aliases.items():
         if alias in remapped_args:
             new, eol_version = _validated_deprecation_spec(new_spec)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="1.8.0",
+        version="1.8.1",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",


### PR DESCRIPTION
Tightened up some stuff in the deprecation util - was missing a place where tuple-handling should have been adjusted, which pointed out that said tuple-handling really should have been encapsulated in its own helper method, which inspired more thoughts about crazy inputs we might expect and deal with.

Whether this PR represents a badge of honor or a cry for help is left as an exercise for the reader.

