### PR TITLE
Fix: 118 marshmallow 3.0 breakage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,20 @@ Changelog
 =========
 
 
+v1.9.1 (2019-08-20)
+-------------------
+
+Fix
+~~~
+- 118 - pinned to an incompatible version of Marshmallow (3.0.0) [Rick Riensche]
+
+  * Changes between 3.0.0rc5 and the actual release of 3.0.0 made our presumptive compatibility changes no longer sufficient
+
+- Relax overly-sensitive test (#117) [Rick Riensche]
+
+  * Deals with a subtle change in returned data on "Invalid input type" schema validation error between marshmallow 2.19 and 2.20. In return from Schema.load, "data" changed from empty dictionary to None, and we had an overzealous test that was expecting empty dictionary; whereas the value of "data" in this scenario appears to be undefined.
+
+
 v1.9.0 (2019-07-24)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=("test*", "examples")),
         include_package_data=True,
         extras_require={"dev": development},
-        install_requires=["Flask>=0.10,<2", "marshmallow>=2.13,<4"],
+        install_requires=["Flask>=0.10,<2", "marshmallow>=2.13,<3"],
         url="https://github.com/plangrid/flask-rebar",
         classifiers=[
             "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ development = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="1.9.0",
+        version="1.9.1",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",


### PR DESCRIPTION
Fixes #113  
Having pin `< 4` is a bug - the actual release of Marshmallow 3.0.0 is **not** compatible with Rebar 1.9.  Because we don't reference any prelease in the pin, the only way for someone to have been operating against something newer than 2.* would have required them to explicitly have installed something like 3.0.0rc6 or lower (overriding PIP's default behavior, which they can still do, hence my judgment that this is not a breaking change and rather a mere patch).