### PR TITLE
BP-763: Add support for multiple authenticators

### DIFF
--- a/docs/quickstart/authentication.rst
+++ b/docs/quickstart/authentication.rst
@@ -21,7 +21,7 @@ Flask-Rebar ships with a ``HeaderApiKeyAuthenticator``.
    @registry.handles(
       rule='/todos/<id>',
       method='GET',
-      authenticators=[authenticator],
+      authenticators=authenticator,
    )
    def get_todo(id):
        ...
@@ -45,7 +45,7 @@ This also supports very lightweight way to identify clients based on the value o
    @registry.handles(
       rule='/todos/<id>',
       method='GET',
-      authenticator=authenticator,
+      authenticators=authenticator,
    )
    def get_todo(id):
        app_name = authenticator.authenticated_app_name
@@ -62,7 +62,7 @@ An authenticator can be added as the default headers schema for all handlers via
 
 .. code-block:: python
 
-   registry.set_default_authenticators([authenticator])
+   registry.set_default_authenticator(authenticator)
 
 This default can be extended for any particular handler by passing flask_rebar.authenticators.USE_DEFAULT as one of the authenticators.
 This default can be overriden in any particular handler by setting ``authenticators`` to something else, including ``None`` to bypass any authentication.

--- a/docs/quickstart/authentication.rst
+++ b/docs/quickstart/authentication.rst
@@ -21,7 +21,7 @@ Flask-Rebar ships with a ``HeaderApiKeyAuthenticator``.
    @registry.handles(
       rule='/todos/<id>',
       method='GET',
-      authenticator=authenticator,
+      authenticators=[authenticator],
    )
    def get_todo(id):
        ...
@@ -62,9 +62,10 @@ An authenticator can be added as the default headers schema for all handlers via
 
 .. code-block:: python
 
-   registry.set_default_authenticator(authenticator)
+   registry.set_default_authenticators([authenticator])
 
-This default can be overriden in any particular handler by setting ``authenticator`` to something else, including ``None`` to bypass any authentication.
+This default can be extended for any particular handler by passing flask_rebar.authenticators.USE_DEFAULT as one of the authenticators.
+This default can be overriden in any particular handler by setting ``authenticators`` to something else, including ``None`` to bypass any authentication.
 
 This Header API Key authentication mechanism was designed to work for services behind some sort of reverse proxy that is handling the harder bits of client authentication.
 

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -322,6 +322,14 @@ class HandlerRegistry(object):
             [authenticator] if authenticator is not None else []
         )
 
+    def set_default_authenticators(self, authenticators):
+        """
+       Sets the handler authenticators to be used by default.
+
+       :param List(flask_rebar.authenticators.Authenticator) authenticators:
+       """
+        self.default_authenticators = authenticators or []
+
     def set_default_headers_schema(self, headers_schema):
         """
         Sets the schema to be used by default to validate incoming headers.

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -638,7 +638,7 @@ class Rebar(object):
         default_authenticator=(
             "default_authenticators",
             "3.0",
-            lambda x: [x] if x is not None else [],
+            _convert_authenticator_to_authenticators,
         )
     )
     def create_handler_registry(

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -620,7 +620,7 @@ class Rebar(object):
     def create_handler_registry(
         self,
         prefix=None,
-        default_authenticators=None,  # TODO deprecate
+        default_authenticators=None,
         default_headers_schema=None,
         default_mimetype=None,
         swagger_generator=None,

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -585,10 +585,17 @@ class Rebar(object):
         self.paths = defaultdict(dict)
         self.uncaught_exception_handlers = []
 
+    @deprecated_parameters(
+        default_authenticator=(
+            "default_authenticators",
+            "3.0",
+            lambda x: [x] if x is not None else [],
+        )
+    )
     def create_handler_registry(
         self,
         prefix=None,
-        default_authenticator=None,  # TODO deprecate
+        default_authenticators=None,  # TODO deprecate
         default_headers_schema=None,
         default_mimetype=None,
         swagger_generator=None,
@@ -606,8 +613,8 @@ class Rebar(object):
 
         :param str prefix:
             URL prefix for all handlers registered with this registry instance.
-        :param flask_rebar.authenticators.Authenticator default_authenticator:
-            Authenticator to use for all handlers as a default.
+        :param List(flask_rebar.authenticators.Authenticator) default_authenticators:
+            List of Authenticators to use for all handlers as a default.
         :param marshmallow.Schema default_headers_schema:
             Schema to validate the headers on all requests as a default.
         :param str default_mimetype:
@@ -627,9 +634,7 @@ class Rebar(object):
         """
         registry = HandlerRegistry(
             prefix=prefix,
-            default_authenticators=[default_authenticator]
-            if default_authenticator is not None
-            else [],
+            default_authenticators=default_authenticators,
             default_headers_schema=default_headers_schema,
             default_mimetype=default_mimetype,
             swagger_generator=swagger_generator,

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -387,7 +387,10 @@ class HandlerRegistry(object):
 
         return paths
 
-    @deprecated_parameters(marshal_schema=("response_body_schema", "2.0"))
+    @deprecated_parameters(
+        marshal_schema=("response_body_schema", "2.0"),
+        authenticator=("authenticators", "3.0", lambda x: [x] if x is not None else []),
+    )
     def add_handler(
         self,
         func,
@@ -398,7 +401,7 @@ class HandlerRegistry(object):
         query_string_schema=None,
         request_body_schema=None,
         headers_schema=USE_DEFAULT,
-        authenticator=USE_DEFAULT,
+        authenticators=USE_DEFAULT,
         tags=None,
         mimetype=USE_DEFAULT,
     ):
@@ -422,8 +425,8 @@ class HandlerRegistry(object):
             assumes everything is JSON.
         :param Type[USE_DEFAULT]|None|marshmallow.Schema headers_schema:
             Schema to use to grab and validate headers.
-        :param Type[USE_DEFAULT]|None|flask_rebar.framing.authenticators.Authenticator authenticator:
-            An authenticator object to authenticate incoming requests.
+        :param Type[USE_DEFAULT]|None|List(flask_rebar.framing.authenticators.Authenticator) authenticators:
+            A list of authenticator objects to authenticate incoming requests.
             If left as USE_DEFAULT, the Rebar's default will be used.
             Set to None to make this an unauthenticated handler.
         :param Sequence[str] tags:
@@ -443,12 +446,21 @@ class HandlerRegistry(object):
             query_string_schema=query_string_schema,
             request_body_schema=request_body_schema,
             headers_schema=headers_schema,
-            authenticators=[authenticator] if authenticator is not None else [],
+            authenticators=(
+                [USE_DEFAULT]
+                if authenticators is USE_DEFAULT
+                else []
+                if authenticators is None
+                else authenticators
+            ),
             tags=tags,
             mimetype=mimetype,
         )
 
-    @deprecated_parameters(marshal_schema=("response_body_schema", "2.0"))
+    @deprecated_parameters(
+        marshal_schema=("response_body_schema", "2.0"),
+        authenticator=("authenticators", "3.0", lambda x: [x] if x is not None else []),
+    )
     def handles(
         self,
         rule,
@@ -458,7 +470,7 @@ class HandlerRegistry(object):
         query_string_schema=None,
         request_body_schema=None,
         headers_schema=USE_DEFAULT,
-        authenticator=USE_DEFAULT,
+        authenticators=USE_DEFAULT,
         tags=None,
         mimetype=USE_DEFAULT,
     ):
@@ -477,7 +489,7 @@ class HandlerRegistry(object):
                 query_string_schema=query_string_schema,
                 request_body_schema=request_body_schema,
                 headers_schema=headers_schema,
-                authenticator=authenticator,
+                authenticators=authenticators,
                 tags=tags,
                 mimetype=mimetype,
             )

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -48,6 +48,17 @@ else:
     PERMANENT_REDIRECT_ERROR = RequestRedirect
 
 
+def _convert_authenticator_to_authenticators(authenticator):
+    if isinstance(authenticator, Authenticator) or authenticator is USE_DEFAULT:
+        return [authenticator]
+    elif authenticator is None:
+        return []
+    else:
+        raise ValueError(
+            "authenticator must be an instance of Authenticator, USE_DEFAULT, or None."
+        )
+
+
 def _unpack_view_func_return_value(rv):
     """
     Normalize a return value from a view function into a tuple of (body, status, headers).
@@ -229,7 +240,11 @@ class PathDefinition(
 
     @deprecated_parameters(marshal_schema=("response_body_schema", "2.0"))
     @deprecated_parameters(
-        authenticator=("authenticators", "3.0", lambda x: [x] if x is not None else [])
+        authenticator=(
+            "authenticators",
+            "3.0",
+            _convert_authenticator_to_authenticators,
+        )
     )
     def __new__(cls, *args, **kwargs):
         return super(PathDefinition, cls).__new__(cls, *args, **kwargs)
@@ -285,7 +300,7 @@ class HandlerRegistry(object):
         default_authenticator=(
             "default_authenticators",
             "3.0",
-            lambda x: [x] if x is not None else [],
+            _convert_authenticator_to_authenticators,
         )
     )
     def __init__(
@@ -395,7 +410,11 @@ class HandlerRegistry(object):
 
     @deprecated_parameters(
         marshal_schema=("response_body_schema", "2.0"),
-        authenticator=("authenticators", "3.0", lambda x: [x] if x is not None else []),
+        authenticator=(
+            "authenticators",
+            "3.0",
+            _convert_authenticator_to_authenticators,
+        ),
     )
     def add_handler(
         self,
@@ -443,6 +462,7 @@ class HandlerRegistry(object):
         if isinstance(response_body_schema, marshmallow.Schema):
             response_body_schema = {200: response_body_schema}
 
+        # authenticators can be a list of Authenticators, a single Authenticator, USE_DEFAULT, or None
         if isinstance(authenticators, Authenticator) or authenticators is USE_DEFAULT:
             authenticators = [authenticators]
         elif authenticators is None:
@@ -464,7 +484,11 @@ class HandlerRegistry(object):
 
     @deprecated_parameters(
         marshal_schema=("response_body_schema", "2.0"),
-        authenticator=("authenticators", "3.0", lambda x: [x] if x is not None else []),
+        authenticator=(
+            "authenticators",
+            "3.0",
+            _convert_authenticator_to_authenticators,
+        ),
     )
     def handles(
         self,

--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -311,9 +311,10 @@ class AuthenticatorConverter(object):
         security_definitions = {}
 
         authenticators = set(
-            d.authenticator
+            authenticator
             for d in iterate_path_definitions(paths=registry.paths)
-            if d.authenticator is not None and d.authenticator is not USE_DEFAULT
+            for authenticator in d.authenticators
+            if authenticator is not None and authenticator is not USE_DEFAULT
         )
 
         if registry.default_authenticator is not None:

--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -317,8 +317,9 @@ class AuthenticatorConverter(object):
             if authenticator is not None and authenticator is not USE_DEFAULT
         )
 
-        if registry.default_authenticator is not None:
-            authenticators.add(registry.default_authenticator)
+        for default_authenticator in registry.default_authenticators:
+            if default_authenticator is not None:
+                authenticators.add(default_authenticator)
 
         for authenticator in authenticators:
             klass = authenticator.__class__

--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -116,7 +116,7 @@ class SwaggerV2Generator(SwaggerGenerator):
         :param bool sort_keys: Use OrderedDicts sorted by keys instead of dicts
         :rtype: dict
         """
-        default_authenticator = registry.default_authenticator
+        default_authenticators = registry.default_authenticators
         security_definitions = self.authenticator_converter.get_security_schemes(
             registry
         )
@@ -146,12 +146,14 @@ class SwaggerV2Generator(SwaggerGenerator):
             sw.definitions: definitions,
         }
 
-        if default_authenticator:
-            swagger[
-                sw.security
-            ] = self.authenticator_converter.get_security_requirement(
-                default_authenticator
-            )
+        if default_authenticators:
+            swagger[sw.security] = [
+                self.authenticator_converter.get_security_requirement(
+                    default_authenticator
+                )[0]
+                for default_authenticator in default_authenticators
+                if default_authenticator is not None
+            ]
 
         if self.tags:
             swagger[sw.tags] = [tag.as_swagger() for tag in self.tags]

--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -280,14 +280,18 @@ class SwaggerV2Generator(SwaggerGenerator):
                 if parameters_definition:
                     path_definition[method_lower][sw.parameters] = parameters_definition
 
-                if d.authenticator is None:
+                if not d.authenticators:
                     path_definition[method_lower][sw.security] = []
-                elif d.authenticator is not USE_DEFAULT:
-                    security = self.authenticator_converter.get_security_requirement(
-                        d.authenticator
-                    )
-                    path_definition[method_lower][sw.security] = security
-
+                else:
+                    security = [
+                        self.authenticator_converter.get_security_requirement(
+                            authenticator
+                        )[0]
+                        for authenticator in d.authenticators
+                        if authenticator is not USE_DEFAULT
+                    ]
+                    if security:
+                        path_definition[method_lower][sw.security] = security
                 if d.tags:
                     path_definition[method_lower][sw.tags] = d.tags
 

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -100,12 +100,14 @@ class SwaggerV3Generator(SwaggerGenerator):
             sw.components: components,
         }
 
-        if registry.default_authenticator:
-            swagger[
-                sw.security
-            ] = self.authenticator_converter.get_security_requirement(
-                registry.default_authenticator
-            )
+        if registry.default_authenticators:
+            swagger[sw.security] = [
+                self.authenticator_converter.get_security_requirement(
+                    default_authenticator
+                )[0]
+                for default_authenticator in registry.default_authenticators
+                if default_authenticator is not None
+            ]
 
         if self.tags:
             swagger[sw.tags] = [tag.as_swagger() for tag in self.tags]

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -235,13 +235,18 @@ class SwaggerV3Generator(SwaggerGenerator):
                 if request_body:
                     path_definition[method_lower][sw.request_body] = request_body
 
-                if d.authenticator is None:
+                if not d.authenticators:
                     path_definition[method_lower][sw.security] = []
-                elif d.authenticator is not USE_DEFAULT:
-                    security = self.authenticator_converter.get_security_requirement(
-                        d.authenticator
-                    )
-                    path_definition[method_lower][sw.security] = security
+                else:
+                    security = [
+                        self.authenticator_converter.get_security_requirement(
+                            authenticator
+                        )[0]
+                        for authenticator in d.authenticators
+                        if authenticator is not USE_DEFAULT
+                    ]
+                    if security:
+                        path_definition[method_lower][sw.security] = security
 
                 if d.tags:
                     path_definition[method_lower][sw.tags] = d.tags

--- a/flask_rebar/utils/deprecation.py
+++ b/flask_rebar/utils/deprecation.py
@@ -65,7 +65,7 @@ def deprecated(new_func=None, eol_version=None):
     def decorator(f):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
-            new, eol = _validated_deprecation_spec(new_func)
+            new, eol, _ = _validated_deprecation_spec(new_func)
             eol = eol_version or eol
             _deprecation_warning(f.__name__, new, eol, stacklevel=3)
             return f(*args, **kwargs)
@@ -78,8 +78,10 @@ def deprecated(new_func=None, eol_version=None):
 def deprecated_parameters(**aliases):
     """
     Adapted from https://stackoverflow.com/a/49802489/977046
-    :param aliases: Keyword args in the form {old_param_name = Union[new_param_name, (new_param_name, eol_version)]}
-                    where eol_version is the version in which the alias may case to be recognized
+    :param aliases: Keyword args in the form {old_param_name = Union[new_param_name, (new_param_name, eol_version),
+                    (new_param_name, eol_version, coerce_func)]}
+                    where eol_version is the version in which the alias may case to be recognized and coerce_func is a
+                    function used to coerce old values to new values.
     :return: function decorator that will apply aliases to param names and raise DeprecationWarning
     """
 
@@ -96,25 +98,30 @@ def deprecated_parameters(**aliases):
 
 def _validated_deprecation_spec(spec):
     """
-    :param Union[new_name, (new_name, eol_version)] spec:  new name and/or expected end-of-life version
-    :return: (str new_name, str eol_version), normalized to tuple and sanitized to deal with malformed inputs
+    :param Union[new_name, (new_name, eol_version), (new_name, eol_version, coerce_func)] spec:
+        new name and/or expected end-of-life version
+    :return: (str new_name, str eol_version, func coerce_func),
+        normalized to tuple and sanitized to deal with malformed inputs
     Parse a deprecation spec (string or tuple) to a standardized namedtuple form.
     If spec is provided as a bare value (presumably string), we'll treat as new name with no end-of-life version
     If spec is provided (likely on accident) as a 1-element tuple, we'll treat same as a bare value
-    If spec is provided as a tuple with more than 2 elements, we'll simply ignore the extraneous
+    If spec is provided as a tuple with more than 3 elements, we'll simply ignore the extraneous
     """
     new_name = None
     eol_version = None
+    coerce_func = None
     if type(spec) is tuple:
         if len(spec) > 0:
             new_name = str(spec[0]) if spec[0] else None
         if len(spec) > 1:
             eol_version = str(spec[1]) if spec[1] else None
+        if len(spec) > 2:
+            coerce_func = spec[2]
     elif spec:
         new_name = str(spec)
-    validated = namedtuple("deprecation_spec", ["new_name", "eol_version"])(
-        new_name, eol_version
-    )
+    validated = namedtuple(
+        "deprecation_spec", ["new_name", "eol_version", "coerce_func"]
+    )(new_name, eol_version, coerce_func)
     return validated
 
 
@@ -125,7 +132,7 @@ def _remap_kwargs(func_name, kwargs, aliases):
     remapped_args = dict(kwargs)
     for alias, new_spec in aliases.items():
         if alias in remapped_args:
-            new, eol_version = _validated_deprecation_spec(new_spec)
+            new, eol_version, coerce_func = _validated_deprecation_spec(new_spec)
             if new in remapped_args:
                 raise TypeError(
                     "{} received both {} and {}".format(func_name, alias, new)
@@ -133,8 +140,10 @@ def _remap_kwargs(func_name, kwargs, aliases):
             else:
                 _deprecation_warning(alias, new, eol_version, stacklevel=4)
                 if new:
-                    remapped_args[new] = remapped_args.pop(alias)
-
+                    value = remapped_args.pop(alias)
+                    if coerce_func is not None:
+                        value = coerce_func(value)
+                    remapped_args[new] = value
     return remapped_args
 
 

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -57,7 +57,7 @@ def get_foo(foo_uid):
     method="PATCH",
     marshal_schema={200: FooSchema()},
     request_body_schema=FooUpdateSchema(),
-    authenticators=[authenticator],
+    authenticators=authenticator,
 )
 def update_foo(foo_uid):
     pass

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -1,0 +1,458 @@
+import marshmallow as m
+
+from flask_rebar import Rebar
+from flask_rebar import HeaderApiKeyAuthenticator
+from flask_rebar import compat
+from flask_rebar.authenticators import USE_DEFAULT
+
+rebar = Rebar()
+registry = rebar.create_handler_registry()
+
+authenticator = HeaderApiKeyAuthenticator(header="x-auth")
+default_authenticator = HeaderApiKeyAuthenticator(header="x-another", name="default")
+alternative_default_authenticator = HeaderApiKeyAuthenticator(
+    header="x-api", name="alternative"
+)
+
+
+class HeaderSchema(m.Schema):
+    user_id = compat.set_data_key(field=m.fields.String(required=True), key="X-UserId")
+
+
+class FooSchema(m.Schema):
+    __swagger_title__ = "Foo"
+
+    uid = m.fields.String()
+    name = m.fields.String()
+
+
+class NestedFoosSchema(m.Schema):
+    data = m.fields.Nested(FooSchema, many=True)
+
+
+class FooUpdateSchema(m.Schema):
+    __swagger_title = "FooUpdate"
+
+    name = m.fields.String()
+
+
+class NameAndOtherSchema(m.Schema):
+    name = m.fields.String()
+    other = m.fields.String()
+
+
+@registry.handles(
+    rule="/foos/<uuid_string:foo_uid>",
+    method="GET",
+    marshal_schema={200: FooSchema()},
+    headers_schema=HeaderSchema(),
+)
+def get_foo(foo_uid):
+    """helpful description"""
+    pass
+
+
+@registry.handles(
+    rule="/foos/<foo_uid>",
+    method="PATCH",
+    marshal_schema={200: FooSchema()},
+    request_body_schema=FooUpdateSchema(),
+    authenticators=[authenticator],
+)
+def update_foo(foo_uid):
+    pass
+
+
+# Test using Schema(many=True) without using a nested Field.
+# https://github.com/plangrid/flask-rebar/issues/41
+@registry.handles(
+    rule="/foo_list",
+    method="GET",
+    marshal_schema={200: FooSchema(many=True)},
+    authenticators=[USE_DEFAULT, authenticator],  # Extend the default!
+)
+def list_foos():
+    pass
+
+
+@registry.handles(
+    rule="/foos",
+    method="GET",
+    marshal_schema={200: NestedFoosSchema()},
+    query_string_schema=NameAndOtherSchema(),
+    authenticator=None,  # Override the default!
+)
+def nested_foos():
+    pass
+
+
+@registry.handles(rule="/tagged_foos", tags=["bar", "baz"])
+def tagged_foos():
+    pass
+
+
+registry.set_default_authenticators(
+    [default_authenticator, alternative_default_authenticator]
+)
+
+
+EXPECTED_SWAGGER_V2 = {
+    "swagger": "2.0",
+    "host": "swag.com",
+    "consumes": ["application/json"],
+    "produces": ["application/json"],
+    "schemes": [],
+    "securityDefinitions": {
+        "sharedSecret": {"type": "apiKey", "in": "header", "name": "x-auth"},
+        "default": {"type": "apiKey", "in": "header", "name": "x-another"},
+        "alternative": {"type": "apiKey", "in": "header", "name": "x-api"},
+    },
+    "security": [{"default": []}, {"alternative": []}],
+    "info": {"title": "My API", "version": "1.0.0", "description": ""},
+    "paths": {
+        "/foos/{foo_uid}": {
+            "parameters": [
+                {"name": "foo_uid", "in": "path", "required": True, "type": "string"}
+            ],
+            "get": {
+                "operationId": "get_foo",
+                "description": "helpful description",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "schema": {"$ref": "#/definitions/Foo"},
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    },
+                },
+                "parameters": [
+                    {
+                        "name": "X-UserId",
+                        "in": "header",
+                        "required": True,
+                        "type": "string",
+                    }
+                ],
+            },
+            "patch": {
+                "operationId": "update_foo",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "schema": {"$ref": "#/definitions/Foo"},
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    },
+                },
+                "parameters": [
+                    {
+                        "name": "FooUpdateSchema",
+                        "in": "body",
+                        "required": True,
+                        "schema": {"$ref": "#/definitions/FooUpdateSchema"},
+                    }
+                ],
+                "security": [{"sharedSecret": []}],
+            },
+        },
+        "/foo_list": {
+            "get": {
+                "operationId": "list_foos",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "schema": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/Foo"},
+                        },
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    },
+                },
+                "security": [
+                    {"default": []},
+                    {"alternative": []},
+                    {"sharedSecret": []},
+                ],
+            }
+        },
+        "/foos": {
+            "get": {
+                "operationId": "nested_foos",
+                "responses": {
+                    "200": {
+                        "description": "NestedFoosSchema",
+                        "schema": {"$ref": "#/definitions/NestedFoosSchema"},
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    },
+                },
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "required": False,
+                        "type": "string",
+                    },
+                    {
+                        "name": "other",
+                        "in": "query",
+                        "required": False,
+                        "type": "string",
+                    },
+                ],
+                "security": [],
+            }
+        },
+        "/tagged_foos": {
+            "get": {
+                "tags": ["bar", "baz"],
+                "operationId": "tagged_foos",
+                "responses": {
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    }
+                },
+            }
+        },
+    },
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "title": "Foo",
+            "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
+        },
+        "FooUpdateSchema": {
+            "type": "object",
+            "title": "FooUpdateSchema",
+            "properties": {"name": {"type": "string"}},
+        },
+        "NestedFoosSchema": {
+            "type": "object",
+            "title": "NestedFoosSchema",
+            "properties": {
+                "data": {"type": "array", "items": {"$ref": "#/definitions/Foo"}}
+            },
+        },
+        "Error": {
+            "type": "object",
+            "title": "Error",
+            "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
+            "required": ["message"],
+        },
+    },
+}
+
+
+EXPECTED_SWAGGER_V3 = expected_swagger = {
+    "openapi": "3.0.2",
+    "info": {"title": "My API", "version": "1.0.0", "description": ""},
+    "security": [{"default": []}, {"alternative": []}],
+    "components": {
+        "schemas": {
+            "Foo": {
+                "type": "object",
+                "title": "Foo",
+                "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
+            },
+            "FooUpdateSchema": {
+                "type": "object",
+                "title": "FooUpdateSchema",
+                "properties": {"name": {"type": "string"}},
+            },
+            "NestedFoosSchema": {
+                "type": "object",
+                "title": "NestedFoosSchema",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/Foo"},
+                    }
+                },
+            },
+            "Error": {
+                "type": "object",
+                "title": "Error",
+                "properties": {
+                    "message": {"type": "string"},
+                    "errors": {"type": "object"},
+                },
+                "required": ["message"],
+            },
+        },
+        "securitySchemes": {
+            "sharedSecret": {"type": "apiKey", "in": "header", "name": "x-auth"},
+            "default": {"type": "apiKey", "in": "header", "name": "x-another"},
+            "alternative": {"type": "apiKey", "in": "header", "name": "x-api"},
+        },
+    },
+    "paths": {
+        "/foos/{foo_uid}": {
+            "parameters": [
+                {
+                    "name": "foo_uid",
+                    "in": "path",
+                    "required": True,
+                    "style": "simple",
+                    "schema": {"type": "string"},
+                }
+            ],
+            "get": {
+                "operationId": "get_foo",
+                "description": "helpful description",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Foo"}
+                            }
+                        },
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                },
+                "parameters": [
+                    {
+                        "name": "X-UserId",
+                        "in": "header",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+            },
+            "patch": {
+                "operationId": "update_foo",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Foo"}
+                            }
+                        },
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                },
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/FooUpdateSchema"}
+                        }
+                    },
+                    "required": True,
+                },
+                "security": [{"sharedSecret": []}],
+            },
+        },
+        "/foo_list": {
+            "get": {
+                "operationId": "list_foos",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/components/schemas/Foo"},
+                                }
+                            }
+                        },
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                },
+                "security": [
+                    {"default": []},
+                    {"alternative": []},
+                    {"sharedSecret": []},
+                ],
+            }
+        },
+        "/foos": {
+            "get": {
+                "operationId": "nested_foos",
+                "responses": {
+                    "200": {
+                        "description": "NestedFoosSchema",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedFoosSchema"
+                                }
+                            }
+                        },
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                },
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "name": "other",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "security": [],
+            }
+        },
+        "/tagged_foos": {
+            "get": {
+                "tags": ["bar", "baz"],
+                "operationId": "tagged_foos",
+                "responses": {
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    },
+}

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -25,8 +25,11 @@ from flask_rebar.testing.swagger_jsonschema import (
     SWAGGER_V3_JSONSCHEMA,
 )
 
-from tests.swagger_generation.registries import legacy
-from tests.swagger_generation.registries import exploded_query_string
+from tests.swagger_generation.registries import (
+    legacy,
+    exploded_query_string,
+    multiple_authenticators,
+)
 
 
 def _assert_dicts_equal(a, b):
@@ -217,9 +220,19 @@ def test_path_parameter_types_must_be_the_same_for_same_path(generator):
         (legacy.registry, 3, legacy.EXPECTED_SWAGGER_V3),
         (exploded_query_string.registry, 2, exploded_query_string.EXPECTED_SWAGGER_V2),
         (exploded_query_string.registry, 3, exploded_query_string.EXPECTED_SWAGGER_V3),
+        (
+            multiple_authenticators.registry,
+            2,
+            multiple_authenticators.EXPECTED_SWAGGER_V2,
+        ),
+        (
+            multiple_authenticators.registry,
+            3,
+            multiple_authenticators.EXPECTED_SWAGGER_V3,
+        ),
     ],
 )
-def test_swagger_generator_v2(registry, swagger_version, expected_swagger):
+def test_swagger_generators(registry, swagger_version, expected_swagger):
     if swagger_version == 2:
         swagger_jsonschema = SWAGGER_V2_JSONSCHEMA
         generator = SwaggerV2Generator()

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -188,7 +188,7 @@ class RebarTest(unittest.TestCase):
         authenticator = HeaderApiKeyAuthenticator(header=auth_header)
         authenticator.register_key(app_name="internal", key=auth_secret)
 
-        register_endpoint(registry, authenticators=[authenticator])
+        register_endpoint(registry, authenticators=authenticator)
         app = create_rebar_app(rebar)
 
         resp = app.test_client().get(

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -25,6 +25,8 @@ from flask_rebar.testing.swagger_jsonschema import SWAGGER_V3_JSONSCHEMA
 
 DEFAULT_AUTH_HEADER = "x-default-auth"
 DEFAULT_AUTH_SECRET = "SECRET!"
+DEFAULT_ALTERNATIVE_AUTH_HEADER = "x-api-default-auth"
+DEFAULT_ALTERNATIVE_AUTH_SECRET = "ALSO A SECRET!"
 DEFAULT_RESPONSE = {"uid": "0", "name": "I'm the default for testing!"}
 DEFAULT_ERROR = {"message": messages.internal_server_error}
 
@@ -71,6 +73,12 @@ def auth_headers(header=DEFAULT_AUTH_HEADER, secret=DEFAULT_AUTH_SECRET):
     return dict([(header, secret)])
 
 
+def alternative_auth_headers(
+    header=DEFAULT_ALTERNATIVE_AUTH_HEADER, secret=DEFAULT_ALTERNATIVE_AUTH_SECRET
+):
+    return dict([(header, secret)])
+
+
 def create_rebar_app(rebar):
     app = Flask("RebarTest")
     app.testing = True
@@ -86,6 +94,22 @@ def register_default_authenticator(registry):
     registry.set_default_authenticator(default_authenticator)
 
 
+def register_multiple_authenticators(registry):
+    default_authenticator = HeaderApiKeyAuthenticator(
+        header=DEFAULT_AUTH_HEADER, name="default"
+    )
+    default_authenticator.register_key(app_name="internal", key=DEFAULT_AUTH_SECRET)
+    alternative_default_authenticator = HeaderApiKeyAuthenticator(
+        header=DEFAULT_ALTERNATIVE_AUTH_HEADER, name="alternative"
+    )
+    alternative_default_authenticator.register_key(
+        app_name="internal", key=DEFAULT_ALTERNATIVE_AUTH_SECRET
+    )
+    registry.set_default_authenticators(
+        (default_authenticator, alternative_default_authenticator)
+    )
+
+
 def register_endpoint(
     registry,
     func=None,
@@ -96,7 +120,7 @@ def register_endpoint(
     query_string_schema=None,
     request_body_schema=None,
     headers_schema=None,
-    authenticator=USE_DEFAULT,
+    authenticators=USE_DEFAULT,
 ):
     def default_handler_func(*args, **kwargs):
         return DEFAULT_RESPONSE
@@ -110,7 +134,7 @@ def register_endpoint(
         query_string_schema=query_string_schema,
         request_body_schema=request_body_schema,
         headers_schema=headers_schema,
-        authenticator=authenticator,
+        authenticators=authenticators,
     )
 
 
@@ -131,6 +155,28 @@ class RebarTest(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 401)
 
+    def test_default_authentication_w_multiple(self):
+        rebar = Rebar()
+        registry = rebar.create_handler_registry()
+        register_multiple_authenticators(registry)
+        register_endpoint(registry)
+        app = create_rebar_app(rebar)
+
+        # Test main
+        resp = app.test_client().get(path="/foos/1", headers=auth_headers())
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+
+        # Test alternative
+        resp = app.test_client().get(path="/foos/1", headers=alternative_auth_headers())
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+
+        resp = app.test_client().get(
+            path="/foos/1", headers=auth_headers(secret="LIES!")
+        )
+        self.assertEqual(resp.status_code, 401)
+
     def test_override_authenticator(self):
         auth_header = "x-overridden-auth"
         auth_secret = "BLAM!"
@@ -142,7 +188,7 @@ class RebarTest(unittest.TestCase):
         authenticator = HeaderApiKeyAuthenticator(header=auth_header)
         authenticator.register_key(app_name="internal", key=auth_secret)
 
-        register_endpoint(registry, authenticator=authenticator)
+        register_endpoint(registry, authenticators=[authenticator])
         app = create_rebar_app(rebar)
 
         resp = app.test_client().get(
@@ -159,7 +205,7 @@ class RebarTest(unittest.TestCase):
         rebar = Rebar()
         registry = rebar.create_handler_registry()
         register_default_authenticator(registry)
-        register_endpoint(registry, authenticator=None)
+        register_endpoint(registry, authenticators=None)
         app = create_rebar_app(rebar)
 
         resp = app.test_client().get(path="/foos/1")


### PR DESCRIPTION
Corresponds to Issue #121

- Extended `deprecated_parameters` decorator to allow a coercion function to convert between old and new styles of parameters.
- Adds support for handlers to have multiple Authenticators.
- Adds support for registries to have multiple Authenticators as their default authentication.
- Should mark `authenticator` parameters as deprecated using the deprecation utils

 JIRA Tickets | 
 --------------| 
 [BP-763](https://plangrid.atlassian.net/browse/BP-763)|
