### PR TITLE
Fix marshmallow test helpers

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,11 +1,10 @@
-import pytest
-
+import unittest
 from flask_rebar.compat import MARSHMALLOW_V2, MARSHMALLOW_V3
 
 
-skip_if_marshmallow_not_v2 = pytest.mark.skipif(
+skip_if_marshmallow_not_v2 = unittest.skipIf(
     not MARSHMALLOW_V2, reason="Only applicable for Marshmallow version 2"
 )
-skip_if_marshmallow_not_v3 = pytest.mark.skipif(
+skip_if_marshmallow_not_v3 = unittest.skipIf(
     not MARSHMALLOW_V3, reason="Only applicable for Marshmallow version 3"
 )


### PR DESCRIPTION
- Test helper should now be compatible with all unittest frameworks and not just pytest. 'python setup.py test'  works again.