### PR TITLE
Update authenticators to catch Forbidden exception

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -125,7 +125,7 @@ def _wrap_handler(
                 try:
                     authenticator.authenticate()
                     break  # Short-circuit on first successful authentication
-                except errors.Unauthorized as e:
+                except (errors.Unauthorized, errors.Forbidden) as e:
                     first_error = first_error or e
             else:
                 raise first_error or errors.Unauthorized


### PR DESCRIPTION
If one authenticator throws a Forbidden Exception, it will not be caught by the current code, and thus, will not check the other authenticators. This is a fix to that problem.