### PR TITLE
FIX: Use nullable to specify that the v3 value may be null

### DIFF
--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -277,7 +277,7 @@ class FieldConverter(MarshmallowConverter):
                     )
 
         if context.openapi_version == 3 and obj.allow_none:
-            jsonschema_obj = {sw.any_of: [{sw.type_: sw.null}, jsonschema_obj]}
+            jsonschema_obj['nullable'] = True
 
         return jsonschema_obj
 

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -277,7 +277,7 @@ class FieldConverter(MarshmallowConverter):
                     )
 
         if context.openapi_version == 3 and obj.allow_none:
-            jsonschema_obj['nullable'] = True
+            jsonschema_obj["nullable"] = True
 
         return jsonschema_obj
 

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -129,10 +129,7 @@ class TestConverterRegistry(unittest.TestCase):
 
     def test_primitive_types_openapi_v3(self):
         for field, result in [
-            (
-                m.fields.Integer(allow_none=True),
-                {"type": "integer", "nullable": True},
-            ),
+            (m.fields.Integer(allow_none=True), {"type": "integer", "nullable": True}),
             (
                 QueryParamList(m.fields.Integer()),
                 {"type": "array", "items": {"type": "integer"}, "explode": True},

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -131,7 +131,7 @@ class TestConverterRegistry(unittest.TestCase):
         for field, result in [
             (
                 m.fields.Integer(allow_none=True),
-                {"anyOf": [{"type": "null"}, {"type": "integer"}]},
+                {"type": "integer", "nullable": True},
             ),
             (
                 QueryParamList(m.fields.Integer()),


### PR DESCRIPTION
According to the [OpenAPI v3 specifications](https://swagger.io/docs/specification/data-models/data-types/#null):

> OpenAPI 3.0 does not have an explicit null type as in JSON Schema, but you can use nullable: true to specify that the value may be null. Note that null is different from an empty string "".

Currently, when `allow_none=True` is used to generate a v3 specification, the schema generated will look something like:

`{"anyOf": [{"type": "null"}, {"type": "integer"}]}`

Instead, it should look like:

`{"type": "integer", "nullable": True}`
