### PR TITLE
change host default to localhost

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -62,7 +62,7 @@ class SwaggerV2Generator(SwaggerGenerator):
 
     def __init__(
         self,
-        host="swag.com",
+        host="localhost",
         schemes=(),
         consumes=("application/json",),
         produces=("application/json",),

--- a/tests/swagger_generation/registries/exploded_query_string.py
+++ b/tests/swagger_generation/registries/exploded_query_string.py
@@ -27,7 +27,7 @@ def get_foos():
 
 EXPECTED_SWAGGER_V2 = {
     "swagger": "2.0",
-    "host": "swag.com",
+    "host": "localhost",
     "consumes": ["application/json"],
     "produces": ["application/json"],
     "schemes": [],

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -96,7 +96,7 @@ registry.set_default_authenticator(default_authenticator)
 
 EXPECTED_SWAGGER_V2 = {
     "swagger": "2.0",
-    "host": "swag.com",
+    "host": "localhost",
     "consumes": ["application/json"],
     "produces": ["application/json"],
     "schemes": [],

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -270,7 +270,7 @@ registry.set_default_authenticators(
 
 EXPECTED_SWAGGER_V2 = {
     "swagger": "2.0",
-    "host": "swag.com",
+    "host": "localhost",
     "consumes": ["application/json"],
     "produces": ["application/json"],
     "schemes": [],

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -40,7 +40,7 @@ def _assert_dicts_equal(a, b):
 
 
 def test_swagger_v2_generator_non_registry_parameters():
-    host = "swag.com"
+    host = "localhost"
     schemes = ["http"]
     consumes = ["application/json"]
     produces = ["application/json"]


### PR DESCRIPTION
swag.com can be connected to, but will only return errors.

localhost seems like a more sane default.

closes #77