### PR TITLE
Feature/strict schema

### DIFF
--- a/flask_rebar/validation.py
+++ b/flask_rebar/validation.py
@@ -121,6 +121,10 @@ class ResponseSchema(ActuallyRequireOnDumpMixin, Schema):
         super().__init__(**kwargs)
 
 
+class StrictSchema(RequestSchema, ResponseSchema):
+    pass
+
+
 class Error(Schema):
     message = fields.String(required=True)
     errors = fields.Dict(required=False)

--- a/flask_rebar/validation.py
+++ b/flask_rebar/validation.py
@@ -115,8 +115,10 @@ else:
     RequestSchema = Schema
 
 
+# Define a constructor to please some IDE type checking
 class ResponseSchema(ActuallyRequireOnDumpMixin, Schema):
-    pass
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
 
 class Error(Schema):


### PR DESCRIPTION
Fixes #161 
This adds a new `StrictSchema` which we should recommend for new users in #152. It's a simple combination of `RequestSchema` and `ResponseSchema`. This is also interesting if we want to extend some functionality of marshmallow down the road.

I also added a simple constructor to `ResponseSchema` because of #137. A future improvement (if/when we drop marshmallow v2) would be to have all the keyword arguments so the IDE can pick it up and suggest them to the user. At least now it doesn't show up as an error.