### PR TITLE
WIP: Content type specification

### DIFF
--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -53,7 +53,11 @@ def get_ref_schema(base, schema):
     :return:
     """
     ref = {sw.ref: create_ref(base, get_swagger_title(schema))}
-    return ref if not schema.many else {sw.type_: sw.array, sw.items: ref}
+    return (
+        ref
+        if not getattr(schema, "many", None)
+        else {sw.type_: sw.array, sw.items: ref}
+    )
 
 
 def get_response_description(schema):


### PR DESCRIPTION
This is a quick and dirty proof of concept to allow for the specification of content type other than `application/json` for OpenAPI 3 generation. Currently, it is possible to create an endpoint without specifying the `response_body_schema`, and then returning a `Response` object with the desired content type:

```
@registry.handles(
    rule='/todos',
    method='GET',
    query_string_schema=GetTodosQueryStringSchema(),
)
def get_todos():
    return send_file(pdf, as_attachment=True, mimetype='application/pdf')
```

However, in existing implementation, the generated swagger specification does not reflect the correct content type. This PR is intended to demonstrate a way to allow for the specification of content type using a `__content_type__` magic attribute. Additionally, a primitive `response_body_schema` type is used to allow for responses that are not json objects.

```
class PDF(m.fields.String):
    __content_type__ = "application/pdf"

@registry.handles(
    rule='/todos',
    method='GET',
    query_string_schema=GetTodosQueryStringSchema(),
    response_body_schema=PDF
)
def get_todos():
    return send_file(pdf, as_attachment=True, mimetype='application/pdf')
```

> Possibly related to #91 