### PR TITLE
remove pyyaml pin since it is not needed anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ development = [
     "bumpversion==0.5.3",
     "gitchangelog>=3.0.4,<4.0.0",
     "pre-commit>=1.14.4",
-    "pyyaml<=5.2",
+    "pyyaml",
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have dropped support for python3.4, which is why pyyaml was pinned.