### PR TITLE
authenticator_converter_registry is missing register_type

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.1
+current_version = 1.12.2
 commit = True
 tag = True
 

--- a/flask_rebar/swagger_generation/swagger_generator_base.py
+++ b/flask_rebar/swagger_generation/swagger_generator_base.py
@@ -186,6 +186,10 @@ class SwaggerGenerator(SwaggerGeneratorI):
             (converter_registry or default_registry).get_security_requirements,
             openapi_version=openapi_major_version,
         )
+        registry.register_type = functools.partial(
+            (converter_registry or default_registry).register_type,
+        )
+
         return registry
 
     def get_open_api_version(self):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ development = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="1.12.1",
+        version="1.12.2",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",


### PR DESCRIPTION
this targets the v1 branch since its against a deprecated function

SwaggerGenerator.register_authenticator_converter is currently crashing because register_type doesnt exist
