### PR TITLE
Fix trigger for auto-release on tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,8 +1,9 @@
 name: flask-rebar Release Publish
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Restore the behavior we had with Travis CI (auto build and release to PyPi on tag)