### PR TITLE
Modify validation to occur after dumping the object a serializable form

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Install black"
       run: |
         python -m pip install -U pip
-        python -m pip install black
+        python -m pip install black==19.10b0
         python -m pip freeze
     - name: Run black
       run: |

--- a/flask_rebar/compat.py
+++ b/flask_rebar/compat.py
@@ -17,8 +17,14 @@ def load(schema, data):
 
 
 def dump(schema, data):
-    obj = schema.load(data)  # Deserialize to trigger validation
-    return schema.dump(obj)
+    try:
+        result = schema.dump(data)
+    except Exception as e:
+        if isinstance(e, marshmallow.ValidationError):
+            raise
+        raise marshmallow.ValidationError(str(e))
+    schema.load(result)
+    return result
 
 
 def exclude_unknown_fields(schema):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -75,7 +75,7 @@ class RequireOutputMixinTest(TestCase):
             compat.dump(self.schema, self.data)
         # it's some sort of date error
         self.assertIn(
-            "Not a valid datetime", ctx.exception.messages["validation_required"][0]
+            "'str' object has no attribute 'isoformat'", ctx.exception.messages[0]
         )
 
     def test_required_failed_validate(self):
@@ -127,11 +127,7 @@ class TestCommaSeparatedList(TestCase):
             compat.dump(IntegerList(), {"foos": [42, "two"]})
 
         self.assertEqual(
-            ctx.exception.messages,
-            {
-                # Element 1 in our list should produce error:
-                "foos": {1: ["Not a valid integer."]}
-            },
+            ctx.exception.messages, ["invalid literal for int() with base 10: 'two'"]
         )
 
 


### PR DESCRIPTION
I'd like to also set a global or something to indicate if validation should occur and then pass that to marshall.

Maybe it should be set on a per handler registry basis and overridable per handler?