### PR TITLE
fix: change got squashed by another PR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=("test*", "examples")),
         include_package_data=True,
         extras_require={"dev": development},
-        install_requires=["Flask>=0.10,<2", "marshmallow>=3.0,<4"],
+        install_requires=["Flask>=1.0,<2", "marshmallow>=3.0,<4"],
         url="https://github.com/plangrid/flask-rebar",
         classifiers=[
             "Environment :: Web Environment",


### PR DESCRIPTION
Dropping support for flask < 1.0 was merged but then got overwritten in a subsequent PR