### PR TITLE
Apply black to rebar.py

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -362,10 +362,10 @@ class HandlerRegistry(object):
 
     def set_default_authenticators(self, authenticators):
         """
-       Sets the handler authenticators to be used by default.
+        Sets the handler authenticators to be used by default.
 
-       :param Union(List(flask_rebar.authenticators.Authenticator)) authenticators:
-       """
+        :param Union(List(flask_rebar.authenticators.Authenticator)) authenticators:
+        """
         self.default_authenticators = authenticators or []
 
     def set_default_headers_schema(self, headers_schema):


### PR DESCRIPTION
Noticed while working on #230. (I saw there's a CI status check for `black`, so I ran `black` on the file I was changing (rebar.py) after I made my changes to it, and then found this pre-existing lint. Looks like it didn't cause the `black` status check in #230 to fail anyway, but figured this PR was still worth submitting.)