### PR TITLE
Store "rebar" in app.extensions on rebar.init_app

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -791,6 +791,8 @@ class Rebar(object):
         for registry in self.handler_registries:
             registry.register(app=app)
 
+        app.extensions["rebar"] = {"handler_registries": self.handler_registries}
+
     def _init_error_handling(self, app):
         @app.errorhandler(errors.HttpJsonError)
         def handle_http_error(error):


### PR DESCRIPTION
Include `handler_registries`, so that it's possible to enumerate all the Rebar APIs that a Flask app provides given only a reference to the `app` object.

See https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.extensions for docs about the `Flask.extensions` API, added in Flask v0.7. (And note we don't need to worry about the backwards-compatibility dance mentioned there because Rebar requires Flask ≥ 1.0.)

An example of another popular extension storing its state in `app.extensions` from its `init_app()` can be found here: https://github.com/pallets/flask-sqlalchemy/blob/175cbf44cb091ab0414fba8e7ab92aff55d7aabf/src/flask_sqlalchemy/__init__.py#L870