### PR TITLE
Backport #230 to V1 branch

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -775,6 +775,8 @@ class Rebar(object):
         for registry in self.handler_registries:
             registry.register(app=app)
 
+        app.extensions["rebar"] = {"handler_registries": self.handler_registries}
+
     def _init_error_handling(self, app):
         @app.errorhandler(errors.HttpJsonError)
         def handle_http_error(error):


### PR DESCRIPTION
As per https://github.com/plangrid/flask-rebar/pull/230#issuecomment-834724160.

Quoting #230:
> Store "rebar" in app.extensions on rebar.init_app
> 
> Include handler_registries so that it's possible to enumerate all the
> Rebar APIs a Flask app provides given only a reference to the app object.