### PR TITLE
fix: update list of versions for automated tests + fix broken test

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -25,6 +25,11 @@ jobs:
         - marshmallow=='3.5.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.6.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.7.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.8.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.9.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.10.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.11.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.12.*' flask=='1.1.*' werkzeug=='1.*'
 
     steps:
     - uses: actions/checkout@v1

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -126,8 +126,6 @@ class TestConverterRegistry(unittest.TestCase):
                 {"type": "object", "title": "Foo", "properties": {"a": result}},
             )
 
-            # code change to force tests
-
     def test_primitive_types_openapi_v3(self):
         for field, result in [
             (m.fields.Integer(allow_none=True), {"type": "integer", "nullable": True}),

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -24,6 +24,9 @@ class TestConverterRegistry(unittest.TestCase):
         self.registry = ConverterRegistry()
         self.registry.register_types(ALL_CONVERTERS)
 
+    def do_nothing(self):
+        pass
+
     def test_primitive_types(self):
         for field, result in [
             (m.fields.Integer(), {"type": "integer"}),
@@ -116,7 +119,15 @@ class TestConverterRegistry(unittest.TestCase):
         ]:
 
             class Foo(m.Schema):
+                def test(self):
+                    pass
+
                 a = field
+
+                # in marshmallow >= 3.11.x, if the 'serialize' / 'deserialize' functions for
+                # a field.Method aren't defined, an exception will be raised.
+                x = self.do_nothing
+                y = self.do_nothing
 
             schema = Foo()
             json_schema = self.registry.convert(schema)

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -119,9 +119,6 @@ class TestConverterRegistry(unittest.TestCase):
         ]:
 
             class Foo(m.Schema):
-                def test(self):
-                    pass
-
                 a = field
 
                 # in marshmallow >= 3.11.x, if the 'serialize' / 'deserialize' functions for

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -126,6 +126,8 @@ class TestConverterRegistry(unittest.TestCase):
                 {"type": "object", "title": "Foo", "properties": {"a": result}},
             )
 
+            # code change to force tests
+
     def test_primitive_types_openapi_v3(self):
         for field, result in [
             (m.fields.Integer(allow_none=True), {"type": "integer", "nullable": True}),


### PR DESCRIPTION
- Update list of `marshmallow` minor versions specified for automated tests
- Fix test that started failing in `marshmallow 3.11.x`