### PR TITLE
add support for flask 2.0

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -30,6 +30,9 @@ jobs:
         - marshmallow=='3.10.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.11.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.12.*' flask=='1.1.*' werkzeug=='1.*'
+        - marshmallow=='3.0.*' flask=='2.0.*' werkzeug=='2.*'
+        - marshmallow=='3.6.*' flask=='2.0.*' werkzeug=='2.*'
+        - marshmallow=='3.12.*' flask=='2.0.*' werkzeug=='2.*'
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -31,7 +31,9 @@ jobs:
         - marshmallow=='3.11.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.12.*' flask=='1.1.*' werkzeug=='1.*'
         - marshmallow=='3.0.*' flask=='2.0.*' werkzeug=='2.*'
-        - marshmallow=='3.6.*' flask=='2.0.*' werkzeug=='2.*'
+        - marshmallow=='3.5.*' flask=='2.0.*' werkzeug=='2.*'
+        - marshmallow=='3.10.*' flask=='2.0.*' werkzeug=='2.*'
+        - marshmallow=='3.11.*' flask=='2.0.*' werkzeug=='2.*'
         - marshmallow=='3.12.*' flask=='2.0.*' werkzeug=='2.*'
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ development = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="2.0.0rc2",
+        version="2.0.0rc3",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=("test*", "examples")),
         include_package_data=True,
         extras_require={"dev": development},
-        install_requires=["Flask>=1.0,<2", "marshmallow>=3.0,<4"],
+        install_requires=["Flask>=1.0,<3", "marshmallow>=3.0,<4"],
         url="https://github.com/plangrid/flask-rebar",
         classifiers=[
             "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ development = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="2.0.0rc3",
+        version="2.0.0rc2",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,4 @@
-from flask import json_available
-
-if json_available:
-    from flask import json
+from flask import json
 from werkzeug.utils import cached_property
 
 
@@ -12,8 +9,6 @@ class JsonResponseMixin(object):
 
     @cached_property
     def json(self):
-        if not json_available:  # pragma: no cover
-            raise NotImplementedError
         return json.loads(self.data)
 
 


### PR DESCRIPTION
- updated flask version requirements to allow flask 2.x
- `from flask import json_available` was deprecated in flask 1.x, and removed in flask 2.x. we should no longer need it since we don't support flask 0.x
- added a few version combinations for automated tests using flask v2. 
  - `flask 2` was released in May 2021 whereas `marshmallow 3` was released in 2019. based on that, I added a few older versions + the 3 most recent `marshmallow` versions to test alongside `flask 2.0`. 

in progress:

- install this package locally w/ flask v2 onto some internal repos that use flask-rebar, and see if there are any issues not identified through unit tests.
  - so far, I've tried updating `flask-toolbox` - a bunch of unit tests broke bc of changes in `marshmallow`, but no issues related to `flask-rebar` so far.