### PR TITLE
chg: Add internal error codes 

### DIFF
--- a/flask_rebar/errors.py
+++ b/flask_rebar/errors.py
@@ -30,12 +30,10 @@ class HttpJsonError(Exception):
 
     default_message = None
     http_status_code = None
-    rebar_error_code = None
 
-    def __init__(self, msg=None, additional_data=None, rebar_error_code=None):
+    def __init__(self, msg=None, additional_data=None):
         self.error_message = msg or self.default_message
         self.additional_data = additional_data
-        self.rebar_error_code = rebar_error_code
         super(HttpJsonError, self).__init__(self.error_message)
 
 

--- a/flask_rebar/errors.py
+++ b/flask_rebar/errors.py
@@ -30,10 +30,12 @@ class HttpJsonError(Exception):
 
     default_message = None
     http_status_code = None
+    rebar_error_code = None
 
-    def __init__(self, msg=None, additional_data=None):
+    def __init__(self, msg=None, additional_data=None, rebar_error_code=None):
         self.error_message = msg or self.default_message
         self.additional_data = additional_data
+        self.rebar_error_code = rebar_error_code
         super(HttpJsonError, self).__init__(self.error_message)
 
 

--- a/flask_rebar/messages.py
+++ b/flask_rebar/messages.py
@@ -8,7 +8,6 @@
     :license: MIT, see LICENSE for details.
 """
 from collections import namedtuple
-from enum import IntEnum
 
 
 # machine-friendly equivalents of associated human-friendly messages

--- a/flask_rebar/messages.py
+++ b/flask_rebar/messages.py
@@ -11,19 +11,20 @@ from collections import namedtuple
 from enum import IntEnum
 
 
-class ErrorCode(IntEnum):
-    BODY_VALIDATION_FAILED = 1
-    EMPTY_JSON_BODY = 2
-    INTERNAL_SERVER_ERROR = 3
-    INVALID_AUTH_TOKEN = 4
-    INVALID_JSON = 5
-    MISSING_AUTH_TOKEN = 6
-    QUERY_STRING_VALIDATION_FAILED = 7
-    UNSUPPORTED_CONTENT_TYPE = 8
-    HEADER_VALIDATION_FAILED = 9
-    REQUIRED_FIELD_MISSING = 10
-    REQUIRED_FIELD_EMPTY = 11
-    UNSUPPORTED_FIELDS = 12
+# machine-friendly equivalents of associated human-friendly messages
+class ErrorCode:
+    BODY_VALIDATION_FAILED = "body_validation_failed"
+    EMPTY_JSON_BODY = "empty_json_body"
+    INTERNAL_SERVER_ERROR = "internal_server_error"
+    INVALID_AUTH_TOKEN = "invalid_auth_token"
+    INVALID_JSON = "invalid_json"
+    MISSING_AUTH_TOKEN = "missing_auth_token"
+    QUERY_STRING_VALIDATION_FAILED = "query_string_validation_failed"
+    UNSUPPORTED_CONTENT_TYPE = "unsupported_content_type"
+    HEADER_VALIDATION_FAILED = "header_validation_failed"
+    REQUIRED_FIELD_MISSING = "required_fields_missing"
+    REQUIRED_FIELD_EMPTY = "required_field_empty"
+    UNSUPPORTED_FIELDS = "unsupported_fields"
 
 
 ErrorMessage = namedtuple("ErrorMessage", "message, rebar_error_code")

--- a/flask_rebar/messages.py
+++ b/flask_rebar/messages.py
@@ -7,35 +7,80 @@
     :copyright: Copyright 2018 PlanGrid, Inc., see AUTHORS.
     :license: MIT, see LICENSE for details.
 """
+from collections import namedtuple
+from enum import IntEnum
 
-body_validation_failed = "JSON body parameters are invalid."
 
-empty_json_body = "Fields must be in JSON body."
+class ErrorCode(IntEnum):
+    BODY_VALIDATION_FAILED = 1
+    EMPTY_JSON_BODY = 2
+    INTERNAL_SERVER_ERROR = 3
+    INVALID_AUTH_TOKEN = 4
+    INVALID_JSON = 5
+    MISSING_AUTH_TOKEN = 6
+    QUERY_STRING_VALIDATION_FAILED = 7
+    UNSUPPORTED_CONTENT_TYPE = 8
+    HEADER_VALIDATION_FAILED = 9
+    REQUIRED_FIELD_MISSING = 10
+    REQUIRED_FIELD_EMPTY = 11
+    UNSUPPORTED_FIELDS = 12
 
-internal_server_error = "Sorry, there was an internal error."
 
-invalid_auth_token = "Invalid authentication."
+ErrorMessage = namedtuple("ErrorMessage", "message, rebar_error_code")
 
-invalid_json = "Failed to decode JSON body."
 
-missing_auth_token = "No auth token provided."
-
-query_string_validation_failed = "Query string parameters are invalid."
-
-unsupported_content_type = (
-    "Only payloads with 'content-type' 'application/json' are supported."
+body_validation_failed = ErrorMessage(
+    "JSON body parameters are invalid.", ErrorCode.BODY_VALIDATION_FAILED
 )
 
-header_validation_failed = "Header parameters are invalid"
+empty_json_body = ErrorMessage(
+    "Fields must be in JSON body.", ErrorCode.EMPTY_JSON_BODY
+)
+
+internal_server_error = ErrorMessage(
+    "Sorry, there was an internal error.", ErrorCode.INTERNAL_SERVER_ERROR
+)
+
+invalid_auth_token = ErrorMessage(
+    "Invalid authentication.", ErrorCode.INVALID_AUTH_TOKEN
+)
+
+invalid_json = ErrorMessage("Failed to decode JSON body.", ErrorCode.INVALID_JSON)
+
+missing_auth_token = ErrorMessage(
+    "No auth token provided.", ErrorCode.MISSING_AUTH_TOKEN
+)
+
+query_string_validation_failed = ErrorMessage(
+    "Query string parameters are invalid.", ErrorCode.QUERY_STRING_VALIDATION_FAILED
+)
+
+unsupported_content_type = ErrorMessage(
+    "Only payloads with 'content-type' 'application/json' are supported.",
+    ErrorCode.UNSUPPORTED_CONTENT_TYPE,
+)
+
+header_validation_failed = ErrorMessage(
+    "Header parameters are invalid", ErrorCode.HEADER_VALIDATION_FAILED
+)
 
 
 def required_field_missing(field_name):
-    return "Required field missing: {}".format(field_name)
+    return ErrorMessage(
+        "Required field missing: {}".format(field_name),
+        ErrorCode.REQUIRED_FIELD_MISSING,
+    )
 
 
 def required_field_empty(field_name):
-    return "Value for required field cannot be None: {}".format(field_name)
+    return ErrorMessage(
+        "Value for required field cannot be None: {}".format(field_name),
+        ErrorCode.REQUIRED_FIELD_EMPTY,
+    )
 
 
 def unsupported_fields(field_names):
-    return "Unexpected field: {}".format(",".join(field_names))
+    return ErrorMessage(
+        "Unexpected field: {}".format(",".join(field_names)),
+        ErrorCode.UNSUPPORTED_FIELDS,
+    )

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -850,7 +850,7 @@ class Rebar(object):
         """
         Compiles a response object for an error.
 
-        :param str message:
+        :param Union[messages.ErrorMessage,str] message:
         :param int http_status_code:
           An optional, application-specific error code to add to the response.
         :param dict additional_data:
@@ -859,9 +859,17 @@ class Rebar(object):
           Additional headers to attach to the response.
         :rtype: flask.Response
         """
-        body = {"message": message}
+        if isinstance(message, messages.ErrorMessage):
+            message_text = message.message
+            rebar_error_code = message.rebar_error_code
+        else:
+            message_text = message
+            rebar_error_code = None
+        body = {"message": message_text}
         if additional_data:
             body.update(additional_data)
+        if rebar_error_code:
+            body["rebar_error_code"] = rebar_error_code
         resp = jsonify(body)
         if headers:
             for key, value in headers.items():

--- a/flask_rebar/utils/request_utils.py
+++ b/flask_rebar/utils/request_utils.py
@@ -117,7 +117,7 @@ def raise_400_for_marshmallow_errors(errs, msg):
     Throws a 400 error properly formatted from the given marshmallow errors.
 
     :param dict errs: Error dictionary as returned by marshmallow
-    :param str msg: The overall message to use in the response.
+    :param Union[str,messages.ErrorMessage] msg: The overall message to use in the response.
     :raises: errors.BadRequest
     """
     if not errs:
@@ -128,8 +128,11 @@ def raise_400_for_marshmallow_errors(errs, msg):
     _format_marshmallow_errors_for_response_in_place(copied)
 
     additional_data = {"errors": copied}
+    message, rebar_code = msg if isinstance(msg, tuple) else msg, None
 
-    raise errors.BadRequest(msg=msg, additional_data=additional_data)
+    raise errors.BadRequest(
+        msg=msg, additional_data=additional_data, rebar_error_code=rebar_code
+    )
 
 
 def get_json_body_params_or_400(schema):

--- a/flask_rebar/utils/request_utils.py
+++ b/flask_rebar/utils/request_utils.py
@@ -130,9 +130,7 @@ def raise_400_for_marshmallow_errors(errs, msg):
     additional_data = {"errors": copied}
     message, rebar_code = msg if isinstance(msg, tuple) else msg, None
 
-    raise errors.BadRequest(
-        msg=msg, additional_data=additional_data, rebar_error_code=rebar_code
-    )
+    raise errors.BadRequest(msg=msg, additional_data=additional_data)
 
 
 def get_json_body_params_or_400(schema):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -101,7 +101,7 @@ class TestErrors(unittest.TestCase):
         resp = self.app.test_client().get("/uncaught_errors")
         self.assertEqual(resp.status_code, 500)
         self.assertEqual(resp.content_type, "application/json")
-        self.assertEqual(resp.json, {"message": messages.internal_server_error})
+        self.assertEqual(resp.json, messages.internal_server_error._asdict())
 
     def test_timeouts_log_exceptions(self):
         # in the wild, gunicorn or nginx will cutoff the wsgi server and return a 502
@@ -151,7 +151,7 @@ class TestJsonBodyValidation(unittest.TestCase):
             path="/stuffs", headers={"Content-Type": "application/json"}
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json, {"message": messages.empty_json_body})
+        self.assertEqual(resp.json, messages.empty_json_body._asdict())
 
         resp = self.app.test_client().post(
             path="/stuffs",
@@ -159,7 +159,7 @@ class TestJsonBodyValidation(unittest.TestCase):
             headers={"Content-Type": "text/csv"},
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json, {"message": messages.unsupported_content_type})
+        self.assertEqual(resp.json, messages.unsupported_content_type._asdict())
 
         resp = self.app.test_client().post(
             path="/stuffs",
@@ -167,55 +167,44 @@ class TestJsonBodyValidation(unittest.TestCase):
             headers={"Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json, {"message": messages.invalid_json})
+        self.assertEqual(resp.json, messages.invalid_json._asdict())
 
     def test_json_body_parameter_validation(self):
         # Only field errors
         resp = self.post_json(
             path="/stuffs", data={"foo": "one", "bar": "not-an-email"}
         )
+        expected = messages.body_validation_failed._asdict()
+        expected["errors"] = {
+            "foo": "Not a valid integer.",
+            "bar": "Not a valid email address.",
+        }
+
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.body_validation_failed,
-                "errors": {
-                    "foo": "Not a valid integer.",
-                    "bar": "Not a valid email address.",
-                },
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
         # Only general errors
         resp = self.post_json(
             path="/stuffs", data={"foo": 1, "baz": "This is an unexpected field!"}
         )
+        expected = messages.body_validation_failed._asdict()
+        expected["errors"] = {"baz": "Unknown field."}
         self.assertEqual(resp.status_code, 400)
 
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.body_validation_failed,
-                "errors": {"baz": "Unknown field."},
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
         # Both field errors and general errors
         resp = self.post_json(
             path="/stuffs", data={"baz": "This is an unexpected field!"}
         )
         self.assertEqual(resp.status_code, 400)
+        expected = messages.body_validation_failed._asdict()
+        expected["errors"] = {
+            "baz": "Unknown field.",
+            "foo": "Missing data for required field.",
+        }
 
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.body_validation_failed,
-                "errors": {
-                    "baz": "Unknown field.",
-                    "foo": "Missing data for required field.",
-                },
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
         # Happy path
         resp = self.post_json(path="/stuffs", data={"foo": 1})
@@ -229,25 +218,19 @@ class TestJsonBodyValidation(unittest.TestCase):
                 "nested": {"baz": ["one", "two"], "unexpected": "surprise!"},
             },
         )
+        expected = messages.body_validation_failed._asdict()
+        expected["errors"] = {
+            "bam": "Unknown field.",
+            "foo": "Missing data for required field.",
+            "nested": {
+                "unexpected": "Unknown field.",
+                "baz": {"0": "Not a valid integer.", "1": "Not a valid integer."},
+            },
+        }
+
         self.assertEqual(resp.status_code, 400)
 
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.body_validation_failed,
-                "errors": {
-                    "bam": "Unknown field.",
-                    "foo": "Missing data for required field.",
-                    "nested": {
-                        "unexpected": "Unknown field.",
-                        "baz": {
-                            "0": "Not a valid integer.",
-                            "1": "Not a valid integer.",
-                        },
-                    },
-                },
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
     def test_invalid_json_error(self):
         resp = self.app.test_client().post(
@@ -256,7 +239,7 @@ class TestJsonBodyValidation(unittest.TestCase):
             headers={"Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json, {"message": messages.invalid_json})
+        self.assertEqual(resp.json, messages.invalid_json._asdict())
 
 
 class TestQueryStringValidation(unittest.TestCase):
@@ -282,35 +265,24 @@ class TestQueryStringValidation(unittest.TestCase):
 
     def test_query_string_parameter_validation(self):
         resp = self.app.test_client().get(path="/stuffs?foo=one")
+        expected = messages.query_string_validation_failed._asdict()
+        expected["errors"] = {"foo": "Not a valid integer."}
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.query_string_validation_failed,
-                "errors": {"foo": "Not a valid integer."},
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
         resp = self.app.test_client().get(path="/stuffs?bar=true")
+        expected = messages.query_string_validation_failed._asdict()
+        expected["errors"] = {"foo": "Missing data for required field."}
+
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.query_string_validation_failed,
-                "errors": {"foo": "Missing data for required field."},
-            },
-        )
+        self.assertEqual(resp.json, expected)
 
         resp = self.app.test_client().get(path="/stuffs?foo=1&unexpected=true")
-        self.assertEqual(resp.status_code, 400)
+        expected = messages.query_string_validation_failed._asdict()
+        expected["errors"] = {"unexpected": "Unknown field."}
 
-        self.assertEqual(
-            resp.json,
-            {
-                "message": messages.query_string_validation_failed,
-                "errors": {"unexpected": "Unknown field."},
-            },
-        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json, expected)
 
         resp = self.app.test_client().get(path="/stuffs?foo=1&bar=true&baz=1,2,3")
         self.assertEqual(resp.status_code, 200)

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -31,8 +31,8 @@ DEFAULT_ALTERNATIVE_AUTH_HEADER = "x-api-default-auth"
 DEFAULT_ALTERNATIVE_AUTH_SECRET = "ALSO A SECRET!"
 DEFAULT_RESPONSE = {"uid": "0", "name": "I'm the default for testing!"}
 DEFAULT_ERROR = (
-    messages.internal_server_error._asdict()
-)  # noqa - _asdict is NOT internal.
+    messages.internal_server_error._asdict()  # noqa - _asdict is NOT internal.
+)
 
 
 class FooSchema(m.Schema):

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -30,7 +30,9 @@ DEFAULT_AUTH_SECRET = "SECRET!"
 DEFAULT_ALTERNATIVE_AUTH_HEADER = "x-api-default-auth"
 DEFAULT_ALTERNATIVE_AUTH_SECRET = "ALSO A SECRET!"
 DEFAULT_RESPONSE = {"uid": "0", "name": "I'm the default for testing!"}
-DEFAULT_ERROR = {"message": messages.internal_server_error}
+DEFAULT_ERROR = (
+    messages.internal_server_error._asdict()
+)  # noqa - _asdict is NOT internal.
 
 
 class FooSchema(m.Schema):
@@ -90,15 +92,11 @@ class DefaultResponseSchema(
     name = m.fields.String()
 
 
-def get_json_from_resp(resp):
-    return json.loads(resp.data.decode("utf-8"))
-
-
 def get_swagger(test_client, prefix=None):
     url = "/swagger"
     if prefix:
         url = prefix_url(prefix=prefix, url=url)
-    return get_json_from_resp(test_client.get(url))
+    return test_client.get(url).json
 
 
 def auth_headers(header=DEFAULT_AUTH_HEADER, secret=DEFAULT_AUTH_SECRET):
@@ -180,7 +178,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/foos/1", headers=auth_headers())
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         resp = app.test_client().get(
             path="/foos/1", headers=auth_headers(secret="LIES!")
@@ -197,12 +195,12 @@ class RebarTest(unittest.TestCase):
         # Test main
         resp = app.test_client().get(path="/foos/1", headers=auth_headers())
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         # Test alternative
         resp = app.test_client().get(path="/foos/1", headers=alternative_auth_headers())
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         resp = app.test_client().get(
             path="/foos/1", headers=auth_headers(secret="LIES!")
@@ -227,7 +225,7 @@ class RebarTest(unittest.TestCase):
             path="/foos/1", headers=auth_headers(header=auth_header, secret=auth_secret)
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         # The default authentication doesn't work anymore!
         resp = app.test_client().get(path="/foos/1", headers=auth_headers())
@@ -242,7 +240,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/foos/1")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
     @parametrize(
         "foo_cls,foo_update_cls,use_model",
@@ -274,7 +272,7 @@ class RebarTest(unittest.TestCase):
             headers={"Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), {"uid": "1", "name": "jill"})
+        self.assertEqual(resp.json, {"uid": "1", "name": "jill"})
 
         resp = app.test_client().patch(
             path="/foos/1",
@@ -345,9 +343,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/foos?name=jill")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(
-            get_json_from_resp(resp), {"data": [{"uid": "1", "name": "jill"}]}
-        )
+        self.assertEqual(resp.json, {"data": [{"uid": "1", "name": "jill"}]})
 
         resp = app.test_client().get(path="/foos?foo=bar")  # missing required parameter
         self.assertEqual(resp.status_code, 400)
@@ -381,7 +377,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/me", headers=headers)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), {"user_name": "hello"})
+        self.assertEqual(resp.json, {"user_name": "hello"})
 
         resp = app.test_client().get(
             path="/me", headers=auth_headers()  # Missing the x-name header!
@@ -531,7 +527,7 @@ class RebarTest(unittest.TestCase):
 
             resp = app.test_client().get("/foo")
 
-            body = get_json_from_resp(resp) if resp.data else resp.data.decode()
+            body = resp.json if resp.data else resp.data.decode()
             self.assertEqual(body, expected_body)
             self.assertEqual(resp.status_code, expected_status)
 
@@ -547,7 +543,7 @@ class RebarTest(unittest.TestCase):
 
         self.assertEqual(resp.status_code, 200)
 
-        validate_swagger(get_json_from_resp(resp))
+        validate_swagger(resp.json)
 
     def test_swagger_ui_endpoint_is_automatically_created(self):
         rebar = Rebar()
@@ -572,7 +568,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get("/swagger")
         self.assertEqual(resp.status_code, 200)
-        validate_swagger(get_json_from_resp(resp), SWAGGER_V3_JSONSCHEMA)
+        validate_swagger(resp.json, SWAGGER_V3_JSONSCHEMA)
 
         resp = app.test_client().get("/swagger/ui/")
         self.assertEqual(resp.status_code, 200)
@@ -593,11 +589,11 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/foos/1")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         resp = app.test_client().get(path="/bars/1")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         swagger = get_swagger(test_client=app.test_client())
         self.assertIn("/bars/{foo_uid}", swagger["paths"])
@@ -622,11 +618,11 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/foos/1")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         resp = app.test_client().patch(path="/foos/1")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), DEFAULT_RESPONSE)
+        self.assertEqual(resp.json, DEFAULT_RESPONSE)
 
         resp = app.test_client().post(path="/foos/1")
         self.assertEqual(resp.status_code, 405)
@@ -666,7 +662,7 @@ class RebarTest(unittest.TestCase):
 
         resp = app.test_client().get(path="/me", headers={"x-name": "hello"})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), {"user_name": "hello"})
+        self.assertEqual(resp.json, {"user_name": "hello"})
 
         resp = app.test_client().get(path="/me")
         self.assertEqual(resp.status_code, 400)
@@ -834,20 +830,21 @@ class RebarTest(unittest.TestCase):
         resp = app.test_client().get(path="/my_get_endpoint?name=QuerystringName")
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(
-            get_json_from_resp(resp)["message"], messages.header_validation_failed
+            resp.json["message"], messages.header_validation_failed.message
         )
+
         # violate querystring schema:
         resp = app.test_client().get(path="/my_get_endpoint", headers=expected_headers)
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(
-            get_json_from_resp(resp)["message"], messages.query_string_validation_failed
+            resp.json["message"], messages.query_string_validation_failed.message
         )
         # valid request:
         resp = app.test_client().get(
             path="/my_get_endpoint?name=QuerystringName", headers=expected_headers
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(get_json_from_resp(resp), expected_foo)
+        self.assertEqual(resp.json, expected_foo)
 
         resp = app.test_client().post(
             path="/my_post_endpoint",
@@ -855,9 +852,7 @@ class RebarTest(unittest.TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            get_json_from_resp(resp)["message"], messages.body_validation_failed
-        )
+        self.assertEqual(resp.json["message"], messages.body_validation_failed.message)
 
         resp = app.test_client().post(
             path="/my_post_endpoint",


### PR DESCRIPTION
Fixes #79 - kinda..
Adds an internal `rebar_error_code` to those errors where we have different error messages for the same http status code.
Was also going to include an "error registry" but feeling like that's overkill (ref discussion on the linked Issue)
Note as part of 2.0 release, this is a breaking change.