### PR TITLE
Deprecate all the things

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -95,7 +95,6 @@ def _unpack_view_func_return_value(rv):
     return data, int(status), headers
 
 
-@deprecated_parameters(marshal_schema=("response_body_schema", "2.0"))
 def _wrap_handler(
     f,
     authenticators=None,
@@ -251,7 +250,6 @@ class PathDefinition(
 ):
     __slots__ = ()
 
-    @deprecated_parameters(marshal_schema=("response_body_schema", "2.0"))
     @deprecated_parameters(
         authenticator=(
             "authenticators",
@@ -261,11 +259,6 @@ class PathDefinition(
     )
     def __new__(cls, *args, **kwargs):
         return super(PathDefinition, cls).__new__(cls, *args, **kwargs)
-
-    @property
-    @deprecated("response_body_schema", "2.0")
-    def marshal_schema(self):
-        return self.response_body_schema
 
     @property
     @deprecated("authenticator", "3.0")
@@ -425,12 +418,11 @@ class HandlerRegistry(object):
         return paths
 
     @deprecated_parameters(
-        marshal_schema=("response_body_schema", "2.0"),
         authenticator=(
             "authenticators",
             "3.0",
             _convert_authenticator_to_authenticators,
-        ),
+        )
     )
     def add_handler(
         self,
@@ -514,12 +506,11 @@ class HandlerRegistry(object):
         )
 
     @deprecated_parameters(
-        marshal_schema=("response_body_schema", "2.0"),
         authenticator=(
             "authenticators",
             "3.0",
             _convert_authenticator_to_authenticators,
-        ),
+        )
     )
     def handles(
         self,

--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -308,7 +308,7 @@ class HandlerRegistry(object):
             "3.0",
             _convert_authenticator_to_authenticators,
         ),
-        swagger_path="spec_path",
+        swagger_path="spec_path",  # we didn't specify an EOL for these two, maybe they just live forever (fine imho)
         swagger_ui_path="spec_ui_path",
     )
     def __init__(

--- a/flask_rebar/swagger_generation/authenticator_to_swagger.py
+++ b/flask_rebar/swagger_generation/authenticator_to_swagger.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-from flask_rebar.utils.deprecation import deprecated_parameters
 from flask_rebar.authenticators import HeaderApiKeyAuthenticator, Authenticator
 from .marshmallow_to_swagger import ConverterRegistry
 from . import swagger_words as sw

--- a/flask_rebar/swagger_generation/authenticator_to_swagger.py
+++ b/flask_rebar/swagger_generation/authenticator_to_swagger.py
@@ -183,13 +183,6 @@ class AuthenticatorConverterRegistry(ConverterRegistry):
             authenticator, _Context(openapi_version=openapi_version)
         )
 
-    @deprecated_parameters(converters=("", "2.0"))
-    def __init__(self, *args, **kwargs):
-        super(AuthenticatorConverterRegistry, self).__init__()
-        deprecated_converts = args[0] if args else kwargs.get("", {})
-        for authenticator, method in deprecated_converts.items():
-            self.register(authenticator, method)
-
 
 authenticator_converter_registry = AuthenticatorConverterRegistry()
 authenticator_converter_registry.register_types((HeaderApiKeyConverter(),))

--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -282,6 +282,3 @@ def recursively_convert_dict_to_ordered_dict(obj):
         return [recursively_convert_dict_to_ordered_dict(item) for item in obj]
     else:
         return obj
-
-
-AuthenticatorConverter = AuthenticatorConverterRegistry  # deprecated alias

--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -11,7 +11,6 @@ import copy
 import re
 from collections import namedtuple, OrderedDict
 
-from flask_rebar.utils.deprecation import deprecated
 from flask_rebar.utils.defaults import USE_DEFAULT
 from flask_rebar.swagger_generation import swagger_words as sw
 from flask_rebar.swagger_generation.marshmallow_to_swagger import get_swagger_title
@@ -181,25 +180,6 @@ def format_path_for_swagger(path):
         repl=lambda match: "{{{}}}".format(match.group("name")), string=path
     )
     return subbed_path, args
-
-
-@deprecated(eol_version="2.0")
-def convert_header_api_key_authenticator(authenticator):
-    """
-    Converts a HeaderApiKeyAuthenticator object to a Swagger definition.
-
-    :param flask_rebar.authenticators.HeaderApiKeyAuthenticator authenticator:
-    :rtype: tuple(str, dict)
-    :returns: Tuple where the first item is a name for the authenticator, and
-    the second item is a Swagger definition for it.
-    """
-    key = authenticator.name
-    definition = {
-        sw.name: authenticator.header,
-        sw.in_: sw.header,
-        sw.type_: sw.api_key,
-    }
-    return key, definition
 
 
 def verify_parameters_are_the_same(a, b):

--- a/tests/swagger_generation/registries/hidden_api.py
+++ b/tests/swagger_generation/registries/hidden_api.py
@@ -45,7 +45,7 @@ class NameAndOtherSchema(m.Schema):
 @registry.handles(
     rule="/foos/<uuid_string:foo_uid>",
     method="GET",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     headers_schema=HeaderSchema(),
 )
 def get_foo(foo_uid):
@@ -56,7 +56,7 @@ def get_foo(foo_uid):
 @registry.handles(
     rule="/foos/<foo_uid>",
     method="PATCH",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     request_body_schema=FooUpdateSchema(),
     authenticator=authenticator,
 )
@@ -69,7 +69,7 @@ def update_foo(foo_uid):
 @registry.handles(
     rule="/foo_list",
     method="GET",
-    marshal_schema={200: FooSchema(many=True)},
+    response_body_schema={200: FooSchema(many=True)},
     authenticator=None,  # Override the default!
     hidden=True,
 )
@@ -80,7 +80,7 @@ def list_foos():
 @registry.handles(
     rule="/foos",
     method="GET",
-    marshal_schema={200: NestedFoosSchema()},
+    response_body_schema={200: NestedFoosSchema()},
     query_string_schema=NameAndOtherSchema(),
     authenticator=None,  # Override the default!
 )

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -44,7 +44,7 @@ class NameAndOtherSchema(m.Schema):
 @registry.handles(
     rule="/foos/<uuid_string:foo_uid>",
     method="GET",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     headers_schema=HeaderSchema(),
 )
 def get_foo(foo_uid):
@@ -55,7 +55,7 @@ def get_foo(foo_uid):
 @registry.handles(
     rule="/foos/<foo_uid>",
     method="PATCH",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     request_body_schema=FooUpdateSchema(),
     authenticator=authenticator,
 )
@@ -68,7 +68,7 @@ def update_foo(foo_uid):
 @registry.handles(
     rule="/foo_list",
     method="GET",
-    marshal_schema={200: FooSchema(many=True)},
+    response_body_schema={200: FooSchema(many=True)},
     authenticator=None,  # Override the default!
 )
 def list_foos():
@@ -78,7 +78,7 @@ def list_foos():
 @registry.handles(
     rule="/foos",
     method="GET",
-    marshal_schema={200: NestedFoosSchema()},
+    response_body_schema={200: NestedFoosSchema()},
     query_string_schema=NameAndOtherSchema(),
     authenticator=None,  # Override the default!
 )

--- a/tests/swagger_generation/registries/marshmallow_objects.py
+++ b/tests/swagger_generation/registries/marshmallow_objects.py
@@ -46,7 +46,7 @@ class NameAndOtherModel(mo.Model):
 @registry.handles(
     rule="/foos/<uuid_string:foo_uid>",
     method="GET",
-    marshal_schema={200: FooModel},
+    response_body_schema={200: FooModel},
     headers_schema=HeaderModel,
 )
 def get_foo(foo_uid):
@@ -57,7 +57,7 @@ def get_foo(foo_uid):
 @registry.handles(
     rule="/foos/<foo_uid>",
     method="PATCH",
-    marshal_schema={200: FooModel},
+    response_body_schema={200: FooModel},
     request_body_schema=FooUpdateModel,
     authenticator=authenticator,
 )
@@ -68,7 +68,7 @@ def update_foo(foo_uid):
 @registry.handles(
     rule="/foos",
     method="GET",
-    marshal_schema={200: NestedFoosModel},
+    response_body_schema={200: NestedFoosModel},
     query_string_schema=NameAndOtherModel,
     authenticator=None,  # Override the default!
 )

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -216,7 +216,7 @@ class NameAndOtherSchema(m.Schema):
 @registry.handles(
     rule="/foos/<uuid_string:foo_uid>",
     method="GET",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     headers_schema=HeaderSchema(),
 )
 def get_foo(foo_uid):
@@ -227,7 +227,7 @@ def get_foo(foo_uid):
 @registry.handles(
     rule="/foos/<foo_uid>",
     method="PATCH",
-    marshal_schema={200: FooSchema()},
+    response_body_schema={200: FooSchema()},
     request_body_schema=FooUpdateSchema(),
     authenticators=authenticator,
 )
@@ -240,7 +240,7 @@ def update_foo(foo_uid):
 @registry.handles(
     rule="/foo_list",
     method="GET",
-    marshal_schema={200: FooSchema(many=True)},
+    response_body_schema={200: FooSchema(many=True)},
     authenticators=[USE_DEFAULT, alternative_authenticator],  # Extend the default!
 )
 def list_foos():
@@ -250,7 +250,7 @@ def list_foos():
 @registry.handles(
     rule="/foos",
     method="GET",
-    marshal_schema={200: NestedFoosSchema()},
+    response_body_schema={200: NestedFoosSchema()},
     query_string_schema=NameAndOtherSchema(),
     authenticator=None,  # Override the default!
 )


### PR DESCRIPTION
Fixes #244 
Removes (most of) the things marked for deprecation.
Exceptions:

- Some things are marked as EOL 3.0 so those will live on until next major version bump.
- A couple of parameters in swagger generation were renamed from e.g., `swagger_path` to `spec_path` with no EOL.  I'm hard-pressed to imagine any case where we would need to reintroduce a `swagger_path` so I left them in as "no harm no foul" - we could tag them as EOL 3.0 or just let them live forever.. 🤷 (and on a second look, these were actually just done very recently, so 3.0 is definitely the earliest they would go away if at all)
