### PR TITLE
fix: Remove now-pointless (and worse, broken) DisallowExtraFieldsMixin

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -11,6 +11,8 @@ Version 2.0 (2021-07-26)
 *  Removed support for versions < 3.6 of Python
 *  Removed support for versions < 1.0 of Flask, and added support for Flask 2.x; we now support only Flask 1.x and 2.x.
 *  Removed support for versions < 3.0 of Marshmallow; we now support only Marshmallow 3.x
+*  Removed ``flask_rebar.validation.DisallowExtraFieldsMixin`` - with Marshmallow 3, this is now default behavior.
+  * We now generate appropriate OpenAPI spec based on ``Schema``'s ``Meta`` (ref https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields)
 *  Removed support for previously deprecated parameter names (https://github.com/plangrid/flask-rebar/pull/246/files)
   * In methods that register handlers, ``marshal_schema`` is now ``response_body_schema`` and the former name is no longer supported
   * ``AuthenticatorConverterRegistry`` no longer accepts a ``converters`` parameter when instantiating. Use ``register_type`` on an instance to add a converter

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -240,8 +240,12 @@ class SchemaConverter(MarshmallowConverter):
     def get_additional_properties(self, obj, context):
         if obj.unknown in (m.RAISE, m.EXCLUDE):
             return False
-        else:
+        elif obj.unknown is m.INCLUDE:
             return True
+        else:
+            raise ValueError(
+                f"Unexpected Schema.unknown value {obj.unknown} for {obj} "
+            )
 
 
 class FieldConverter(MarshmallowConverter):

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -25,7 +25,6 @@ from marshmallow.validate import Validator
 from flask_rebar import compat
 from flask_rebar.validation import QueryParamList
 from flask_rebar.validation import CommaSeparatedList
-from flask_rebar.validation import DisallowExtraFieldsMixin
 from flask_rebar.swagger_generation import swagger_words as sw
 
 
@@ -237,6 +236,13 @@ class SchemaConverter(MarshmallowConverter):
         else:
             return UNSET
 
+    @sets_swagger_attr(sw.additional_properties)
+    def get_additional_properties(self, obj, context):
+        if obj.unknown in (m.RAISE, m.EXCLUDE):
+            return False
+        else:
+            return True
+
 
 class FieldConverter(MarshmallowConverter):
     """
@@ -316,14 +322,6 @@ class ValidatorConverter(MarshmallowConverter):
     """
 
     MARSHMALLOW_TYPE = Validator
-
-
-class DisallowExtraFieldsConverter(SchemaConverter):
-    MARSHMALLOW_TYPE = DisallowExtraFieldsMixin
-
-    @sets_swagger_attr(sw.additional_properties)
-    def get_additional_properties(self, obj, context):
-        return False
 
 
 class NestedConverter(FieldConverter):
@@ -686,7 +684,6 @@ request_body_converter_registry.register_types(
         DateConverter(),
         DateTimeConverter(),
         DictConverter(),
-        DisallowExtraFieldsConverter(),
         FunctionConverter(),
         IntegerConverter(),
         LengthConverter(),
@@ -710,7 +707,6 @@ response_converter_registry.register_types(
         DateConverter(),
         DateTimeConverter(),
         DictConverter(),
-        DisallowExtraFieldsConverter(),
         FunctionConverter(),
         IntegerConverter(),
         LengthConverter(),

--- a/flask_rebar/validation.py
+++ b/flask_rebar/validation.py
@@ -73,41 +73,6 @@ class RequireOnDumpMixin(object):
         return data
 
 
-class DisallowExtraFieldsMixin(object):
-    """
-    By default, Marshmallow will silently ignore fields that aren't included in a schema
-    when serializing/deserializing.
-
-    This can be undesirable when doing request validation, as we want to notify a client
-    when unrecognized fields are included.
-
-    This is a `marshmallow.Schema` mixin that will throw an error when an object has
-    unrecognized fields.
-    """
-
-    @validates_schema(pass_original=True)
-    def disallow_extra_fields(self, processed_data, original_data):
-        # If the input data isn't a dict just short-circuit and let the Marshmallow unmarshaller
-        # raise an error.
-        if not isinstance(original_data, dict):
-            return
-
-        input_fields = original_data.keys()
-        expected_fields = list(self.fields) + [
-            field.load_from
-            for field in self.fields.values()
-            if field.load_from is not None
-        ]
-        excluded_fields = self.exclude
-        unsupported_fields = (
-            set(input_fields) - set(expected_fields) - set(excluded_fields)
-        )
-        if len(unsupported_fields) > 0:
-            raise ValidationError(
-                message=messages.unsupported_fields(unsupported_fields)
-            )
-
-
 RequestSchema = Schema
 
 

--- a/tests/swagger_generation/registries/exploded_query_string.py
+++ b/tests/swagger_generation/registries/exploded_query_string.py
@@ -35,6 +35,7 @@ EXPECTED_SWAGGER_V2 = {
     "info": {"title": "My API", "version": "1.0.0", "description": ""},
     "definitions": {
         "Error": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Error",
             "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
@@ -73,6 +74,7 @@ EXPECTED_SWAGGER_V3 = {
     "components": {
         "schemas": {
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {

--- a/tests/swagger_generation/registries/hidden_api.py
+++ b/tests/swagger_generation/registries/hidden_api.py
@@ -222,23 +222,31 @@ EXPECTED_SWAGGER_V2 = {
     },
     "definitions": {
         "Foo": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Foo",
             "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
         },
         "FooUpdateSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "FooUpdateSchema",
             "properties": {"name": {"type": "string"}},
         },
         "NestedFoosSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "NestedFoosSchema",
             "properties": {
-                "data": {"type": "array", "items": {"$ref": "#/definitions/Foo"}}
+                "data": {
+                    "additionalProperties": False,
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Foo"},
+                }
             },
         },
         "Error": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Error",
             "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
@@ -255,26 +263,31 @@ SWAGGER_V3_WITHOUT_HIDDEN = expected_swagger = {
     "components": {
         "schemas": {
             "Foo": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Foo",
                 "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
             },
             "FooUpdateSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "FooUpdateSchema",
                 "properties": {"name": {"type": "string"}},
             },
             "NestedFoosSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "NestedFoosSchema",
                 "properties": {
                     "data": {
+                        "additionalProperties": False,
                         "type": "array",
                         "items": {"$ref": "#/components/schemas/Foo"},
                     }
                 },
             },
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {
@@ -428,26 +441,31 @@ SWAGGER_V3_WITH_HIDDEN = expected_swagger = {
     "components": {
         "schemas": {
             "Foo": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Foo",
                 "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
             },
             "FooUpdateSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "FooUpdateSchema",
                 "properties": {"name": {"type": "string"}},
             },
             "NestedFoosSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "NestedFoosSchema",
                 "properties": {
                     "data": {
+                        "additionalProperties": False,
                         "type": "array",
                         "items": {"$ref": "#/components/schemas/Foo"},
                     }
                 },
             },
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -220,23 +220,31 @@ EXPECTED_SWAGGER_V2 = {
     },
     "definitions": {
         "Foo": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Foo",
             "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
         },
         "FooUpdateSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "FooUpdateSchema",
             "properties": {"name": {"type": "string"}},
         },
         "NestedFoosSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "NestedFoosSchema",
             "properties": {
-                "data": {"type": "array", "items": {"$ref": "#/definitions/Foo"}}
+                "data": {
+                    "additionalProperties": False,
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Foo"},
+                }
             },
         },
         "Error": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Error",
             "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
@@ -253,26 +261,31 @@ EXPECTED_SWAGGER_V3 = expected_swagger = {
     "components": {
         "schemas": {
             "Foo": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Foo",
                 "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
             },
             "FooUpdateSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "FooUpdateSchema",
                 "properties": {"name": {"type": "string"}},
             },
             "NestedFoosSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "NestedFoosSchema",
                 "properties": {
                     "data": {
+                        "additionalProperties": False,
                         "type": "array",
                         "items": {"$ref": "#/components/schemas/Foo"},
                     }
                 },
             },
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {

--- a/tests/swagger_generation/registries/marshmallow_objects.py
+++ b/tests/swagger_generation/registries/marshmallow_objects.py
@@ -191,23 +191,31 @@ EXPECTED_SWAGGER_V2 = {
     },
     "definitions": {
         "Foo": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Foo",
             "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
         },
         "FooUpdateModelSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "FooUpdateModelSchema",
             "properties": {"name": {"type": "string"}},
         },
         "NestedFoosModelSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "NestedFoosModelSchema",
             "properties": {
-                "data": {"type": "array", "items": {"$ref": "#/definitions/Foo"}}
+                "data": {
+                    "additionalProperties": False,
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Foo"},
+                }
             },
         },
         "Error": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Error",
             "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
@@ -224,26 +232,31 @@ EXPECTED_SWAGGER_V3 = expected_swagger = {
     "components": {
         "schemas": {
             "Foo": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Foo",
                 "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
             },
             "FooUpdateModelSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "FooUpdateModelSchema",
                 "properties": {"name": {"type": "string"}},
             },
             "NestedFoosModelSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "NestedFoosModelSchema",
                 "properties": {
                     "data": {
+                        "additionalProperties": False,
                         "type": "array",
                         "items": {"$ref": "#/components/schemas/Foo"},
                     }
                 },
             },
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -416,23 +416,31 @@ EXPECTED_SWAGGER_V2 = {
     },
     "definitions": {
         "Foo": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Foo",
             "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
         },
         "FooUpdateSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "FooUpdateSchema",
             "properties": {"name": {"type": "string"}},
         },
         "NestedFoosSchema": {
+            "additionalProperties": False,
             "type": "object",
             "title": "NestedFoosSchema",
             "properties": {
-                "data": {"type": "array", "items": {"$ref": "#/definitions/Foo"}}
+                "data": {
+                    "additionalProperties": False,
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Foo"},
+                }
             },
         },
         "Error": {
+            "additionalProperties": False,
             "type": "object",
             "title": "Error",
             "properties": {"message": {"type": "string"}, "errors": {"type": "object"}},
@@ -449,26 +457,31 @@ EXPECTED_SWAGGER_V3 = expected_swagger = {
     "components": {
         "schemas": {
             "Foo": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Foo",
                 "properties": {"uid": {"type": "string"}, "name": {"type": "string"}},
             },
             "FooUpdateSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "FooUpdateSchema",
                 "properties": {"name": {"type": "string"}},
             },
             "NestedFoosSchema": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "NestedFoosSchema",
                 "properties": {
                     "data": {
+                        "additionalProperties": False,
                         "type": "array",
                         "items": {"$ref": "#/components/schemas/Foo"},
                     }
                 },
             },
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {

--- a/tests/swagger_generation/test_swagger_generator.py
+++ b/tests/swagger_generation/test_swagger_generator.py
@@ -96,6 +96,7 @@ def test_swagger_v2_generator_non_registry_parameters():
         "paths": {},
         "definitions": {
             "Error": {
+                "additionalProperties": False,
                 "type": "object",
                 "title": "Error",
                 "properties": {
@@ -182,6 +183,7 @@ def test_swagger_v3_generator_non_registry_parameters():
         "components": {
             "schemas": {
                 "Error": {
+                    "additionalProperties": False,
                     "type": "object",
                     "title": "Error",
                     "properties": {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,13 +20,7 @@ from flask_rebar import compat
 from flask_rebar.utils.request_utils import normalize_schema
 from flask_rebar.validation import RequireOnDumpMixin
 from flask_rebar.validation import CommaSeparatedList
-from flask_rebar.validation import DisallowExtraFieldsMixin
 from flask_rebar.validation import QueryParamList
-
-
-class DisallowExtraFieldsSchema(Schema, DisallowExtraFieldsMixin):
-    a = fields.String()
-    b = fields.String(load_from="c")
 
 
 class RequireOnDumpMixinSchema(Schema, RequireOnDumpMixin):


### PR DESCRIPTION
Fixes #249 
With update from Marshmallow 2 to 3, the default behavior has changed - previously it was equivalent to `EXCLUDE` (ignore unexpected fields), whereas now it is `RAISE` (the behavior we previously exposed in our mixin).

Removing this mixin also required moving the appropriate "attribute setter" from a mixin-specific converter class to the primary `SchemaConverter` which has the side effect of making all of our generated OpenAPI specs EXPLICIT when it comes to `additionalProperties`, hence the massive proliferation of changes in tests 