### PR TITLE
Fix filter_dump_only for NoneType nested fields

### DIFF
--- a/flask_rebar/validation.py
+++ b/flask_rebar/validation.py
@@ -71,7 +71,8 @@ def filter_dump_only(schema, data):
             [item.loadable for item in processed_items],
             [item.dump_only for item in processed_items],
         )
-
+    elif data is None:
+        return FilterResult(loadable=dict(), dump_only=dict())
     else:
         # I am not aware of any case where we should get something other than a Mapping or list, but just in case
         # we can raise a hopefully helpful error if there's some weird Schema that can cause that, so we know

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -56,6 +56,10 @@ class OuterNested(Schema, RequireOnDumpMixin):
     nested_list = fields.List(fields.Nested(InnerNested))
 
 
+class OuterNestedNone(Schema, RequireOnDumpMixin):
+    nested = fields.Nested(InnerNested, allow_none=True)
+
+
 class RequireOutputMixinTest(TestCase):
     def setUp(self):
         super(RequireOutputMixinTest, self).setUp()
@@ -234,6 +238,13 @@ class TestComplexNesting(TestCase):
         data["nested"]["inner_nested_list"][2]["one_of_validation"] = "z"
         with self.assertRaises(ValidationError):
             compat.dump(OuterNested(), data)
+
+    def test_validation_nested_none(self):
+        """compat.dump validation works with allow_none nested schemas"""
+        data = self.base_valid_outer_wrapper
+        data["nested"] = None
+        result = compat.dump(OuterNestedNone(), data)
+        self.assertEqual(result["nested"], None)
 
 
 class StringList(Schema):


### PR DESCRIPTION
`filter_dump_only` will erroneously throw a `TypeError: filter_dump_only doesn't understand data type <class 'NoneType'>` error if a nested field marked as `allow_none=True` is `None`