### PR TITLE
Only use EnumConverter if marshmallow-enum present

### DIFF
--- a/flask_rebar/compat.py
+++ b/flask_rebar/compat.py
@@ -1,4 +1,7 @@
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import marshmallow
 

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -687,7 +687,7 @@ def _common_converters():
         UUIDConverter(),
         ConstantConverter(),
     ]
-    if EnumField:
+    if EnumConverter.MARSHMALLOW_TYPE is not None:
         converters.append(EnumConverter())
 
     return converters

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -633,36 +633,30 @@ class ConverterRegistry(object):
         )
 
 
-if EnumField:
+class EnumConverter(FieldConverter):
+    MARSHMALLOW_TYPE = EnumField
 
-    class EnumConverter(FieldConverter):
-        MARSHMALLOW_TYPE = EnumField
-
-        @sets_swagger_attr(sw.type_)
-        def get_type(self, obj, context):
-            # Note: we don't (yet?) support mix-and-match between load_by and dump_by. Pick one.
-            if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
-                # I'm going out on a limb and assuming your enum uses same type for all vals, else caveat emptor:
-                value_type = type(next(iter(obj.enum)).value)
-                if value_type is int:
-                    return sw.integer
-                elif value_type is float:
-                    return sw.number
-                else:
-                    return sw.string
+    @sets_swagger_attr(sw.type_)
+    def get_type(self, obj, context):
+        # Note: we don't (yet?) support mix-and-match between load_by and dump_by. Pick one.
+        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+            # I'm going out on a limb and assuming your enum uses same type for all vals, else caveat emptor:
+            value_type = type(next(iter(obj.enum)).value)
+            if value_type is int:
+                return sw.integer
+            elif value_type is float:
+                return sw.number
             else:
                 return sw.string
+        else:
+            return sw.string
 
-        @sets_swagger_attr(sw.enum)
-        def get_enum(self, obj, context):
-            if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
-                return [entry.value for entry in obj.enum]
-            else:
-                return [entry.name for entry in obj.enum]
-
-
-else:
-    EnumConverter = None
+    @sets_swagger_attr(sw.enum)
+    def get_enum(self, obj, context):
+        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+            return [entry.value for entry in obj.enum]
+        else:
+            return [entry.name for entry in obj.enum]
 
 
 ALL_CONVERTERS = tuple(
@@ -693,7 +687,7 @@ def _common_converters():
         UUIDConverter(),
         ConstantConverter(),
     ]
-    if EnumConverter:
+    if EnumField:
         converters.append(EnumConverter())
 
     return converters

--- a/flask_rebar/validation.py
+++ b/flask_rebar/validation.py
@@ -7,7 +7,11 @@
     :copyright: Copyright 2018 PlanGrid, Inc., see AUTHORS.
     :license: MIT, see LICENSE for details.
 """
-from collections import Mapping, namedtuple
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+from collections import namedtuple
 
 from marshmallow import Schema
 from marshmallow import ValidationError

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ development = [
     "parametrize==0.1.1",
     "pre-commit>=1.14.4",
     "pytest==4.6.8",
+    "pytest-order==1.0.1",
     "Sphinx==1.7.0",
     "sphinx_rtd_theme==0.2.4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ development = [
     "gitchangelog>=3.0.4,<4.0.0",
     "jsonschema==3.0.2",
     "marshmallow-objects~=2.3",
-    "mock==2.0.0",
     "parametrize==0.1.1",
     "pre-commit>=1.14.4",
     "pytest==6.2.5",

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ development = [
     "marshmallow-objects~=2.3",
     "parametrize==0.1.1",
     "pre-commit>=1.14.4",
-    "pytest==6.2.5",
-    "pytest-order==1.0.1",
+    "pytest~=6.2",
+    "pytest-order~=1.0",
     "Sphinx==1.7.0",
     "sphinx_rtd_theme==0.2.4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ development = [
     "mock==2.0.0",
     "parametrize==0.1.1",
     "pre-commit>=1.14.4",
-    "pytest==4.6.8",
+    "pytest==6.2.5",
     "pytest-order==1.0.1",
     "Sphinx==1.7.0",
     "sphinx_rtd_theme==0.2.4",

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -8,8 +8,11 @@
     :license: MIT, see LICENSE for details.
 """
 import enum
+import mock
 import unittest
+from importlib import reload
 from parametrize import parametrize
+
 
 import marshmallow as m
 import marshmallow_enum as me
@@ -17,6 +20,7 @@ from marshmallow import validate as v
 
 from flask_rebar.swagger_generation.marshmallow_to_swagger import ALL_CONVERTERS
 from flask_rebar.swagger_generation.marshmallow_to_swagger import ConverterRegistry
+
 from flask_rebar.validation import CommaSeparatedList
 from flask_rebar.validation import QueryParamList
 
@@ -53,6 +57,10 @@ class TestConverterRegistry(unittest.TestCase):
             (
                 me.EnumField(StopLight),
                 {"enum": ["green", "yellow", "red"], "type": "string"},
+            ),
+            (
+                me.EnumField(StopLight, by_value=True),
+                {"enum": [1, 2, 3], "type": "integer"},
             ),
             (
                 m.fields.Integer(allow_none=True),

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -8,9 +8,7 @@
     :license: MIT, see LICENSE for details.
 """
 import enum
-import mock
-import unittest
-from importlib import reload
+from unittest import TestCase
 from parametrize import parametrize
 
 
@@ -31,7 +29,7 @@ class StopLight(enum.Enum):
     red = 3
 
 
-class TestConverterRegistry(unittest.TestCase):
+class TestConverterRegistry(TestCase):
     def setUp(self):
         self.registry = ConverterRegistry()
         self.registry.register_types(ALL_CONVERTERS)

--- a/tests/swagger_generation/test_optional_converters.py
+++ b/tests/swagger_generation/test_optional_converters.py
@@ -16,7 +16,10 @@ class TestOptionalConverters(TestCase):
         self.assertIsNotNone(_m_to_s.EnumField)
         self.assertTrue(
             any(
-                [type(conv) is _m_to_s.EnumConverter for conv in _m_to_s._common_converters()]
+                [
+                    type(conv) is _m_to_s.EnumConverter
+                    for conv in _m_to_s._common_converters()
+                ]
             )
         )
 

--- a/tests/swagger_generation/test_optional_converters.py
+++ b/tests/swagger_generation/test_optional_converters.py
@@ -1,0 +1,37 @@
+import mock
+import pytest
+import unittest
+from importlib import reload
+
+
+# HAAAAACKS - using importlib.reload will invalidate pre-existing imports in other test modules,
+# even when imported "as" something else..  so we'll just use pytest-order to ensure this test always runs LAST.
+@pytest.mark.order(-1)
+class TestOptionalConverters(unittest.TestCase):
+    def test_optional_enum_converter(self):
+        import flask_rebar.swagger_generation.marshmallow_to_swagger as _m_to_s
+
+        # by default these should be there because tests are run with extras installed
+        self.assertIsNotNone(_m_to_s.EnumField)
+        self.assertIsNotNone(_m_to_s.EnumConverter)
+        self.assertTrue(
+            any(
+                [type(conv) is _m_to_s.EnumConverter for conv in _m_to_s.ALL_CONVERTERS]
+            )
+        )
+        full_len = len(_m_to_s.ALL_CONVERTERS)  # for an extra sanity check
+
+        # simulate marshmallow_enum not installed:
+        with mock.patch("marshmallow_enum.EnumField", new=None):
+            reload(_m_to_s)
+            self.assertIsNone(_m_to_s.EnumField)
+            self.assertIsNone(_m_to_s.EnumConverter)
+            self.assertFalse(
+                any(
+                    [
+                        type(conv) is _m_to_s.EnumConverter
+                        for conv in _m_to_s.ALL_CONVERTERS
+                    ]
+                )
+            )
+            self.assertEqual(len(_m_to_s.ALL_CONVERTERS), full_len - 1)

--- a/tests/swagger_generation/test_optional_converters.py
+++ b/tests/swagger_generation/test_optional_converters.py
@@ -1,37 +1,34 @@
-import mock
 import pytest
-import unittest
+from unittest import mock, TestCase
 from importlib import reload
+
+from flask_rebar.swagger_generation.marshmallow_to_swagger import _common_converters
 
 
 # HAAAAACKS - using importlib.reload will invalidate pre-existing imports in other test modules,
 # even when imported "as" something else..  so we'll just use pytest-order to ensure this test always runs LAST.
 @pytest.mark.order(-1)
-class TestOptionalConverters(unittest.TestCase):
+class TestOptionalConverters(TestCase):
     def test_optional_enum_converter(self):
         import flask_rebar.swagger_generation.marshmallow_to_swagger as _m_to_s
 
         # by default these should be there because tests are run with extras installed
         self.assertIsNotNone(_m_to_s.EnumField)
-        self.assertIsNotNone(_m_to_s.EnumConverter)
         self.assertTrue(
             any(
-                [type(conv) is _m_to_s.EnumConverter for conv in _m_to_s.ALL_CONVERTERS]
+                [type(conv) is _m_to_s.EnumConverter for conv in _m_to_s._common_converters()]
             )
         )
-        full_len = len(_m_to_s.ALL_CONVERTERS)  # for an extra sanity check
 
         # simulate marshmallow_enum not installed:
         with mock.patch("marshmallow_enum.EnumField", new=None):
             reload(_m_to_s)
             self.assertIsNone(_m_to_s.EnumField)
-            self.assertIsNone(_m_to_s.EnumConverter)
             self.assertFalse(
                 any(
                     [
                         type(conv) is _m_to_s.EnumConverter
-                        for conv in _m_to_s.ALL_CONVERTERS
+                        for conv in _m_to_s._common_converters()
                     ]
                 )
             )
-            self.assertEqual(len(_m_to_s.ALL_CONVERTERS), full_len - 1)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,8 +15,8 @@ import unittest
 from flask import Flask
 from marshmallow import fields
 from werkzeug.exceptions import BadRequest
-from mock import ANY
-from mock import patch
+from unittest.mock import ANY
+from unittest.mock import patch
 from tests.helpers import make_test_response
 
 from flask_rebar import messages, validation, response, Rebar


### PR DESCRIPTION
Took a whack at addressing feedback from @barakalon on #257 (in a separate branch just in case we hate what I did)

I'm not sure how I feel about things like conditionally defining classes (I guess it's technically no "worse" than conditional imports, but it still "feels" dirty lol) and having to enforce order within `pytest` but... it does seem to work 🤣 

