### PR TITLE
Try to fix dumping with data_key

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -331,3 +331,13 @@ class TestQueryParamList(TestCase):
         self.assertEqual(
             ctx.exception.messages, {"foos": {1: ["Not a valid integer."]}}
         )
+
+
+class DataKeySchema(RequireOnDumpMixin, Schema):
+    test_field = fields.String(data_key="testField")
+
+
+class TestDataKey(TestCase):
+    def test_dump_and_validate_with_data_key(self):
+        result = compat.dump(DataKeySchema(), {"test_field": "abc"})
+        self.assertEqual(result, {"testField": "abc"})


### PR DESCRIPTION
The test case demonstrates the issue: When using `data_key` in the schema, `filter_dump_only()` fails with `KeyError` because it assumes that the keys in the output are the same as the fields in the schema.

I've tried to fix this issue by adding a dict that translates from the output keys back to the schema fields.