### PR TITLE
fix:Remove periods from blueprint name prefixes

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -617,7 +617,7 @@ class HandlerRegistry(object):
         blueprint_name = "swagger_ui"
 
         if self.prefix:
-            blueprint_name = self.prefix + blueprint_name
+            blueprint_name = self.prefix.replace(".", "_") + blueprint_name
 
         if self.spec_ui_path:
             blueprint = create_swagger_ui_blueprint(


### PR DESCRIPTION
https://github.com/plangrid/flask-rebar/issues/274