### PR TITLE
[PJL-7600] fix minor bug in swagger v3 generator

### DIFF
--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -472,7 +472,11 @@ class CsvArrayConverter(ListConverter):
 
     @sets_swagger_attr(sw.style)
     def get_style(self, obj, context):
-        return sw.simple if context.openapi_version == 3 else UNSET
+        return sw.form if context.openapi_version == 3 else UNSET
+
+    @sets_swagger_attr(sw.explode)
+    def get_explode(self, obj, context):
+        return False if context.openapi_version == 3 else UNSET
 
 
 class MultiArrayConverter(ListConverter):

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -333,6 +333,7 @@ class SwaggerV3Generator(SwaggerGenerator):
             # We need the "explode" key to be at the parameters level, not at the schema level.
             explode = jsonschema.pop(sw.explode, None)
             description = jsonschema.pop(sw.description, None)
+            style = jsonschema.pop(sw.style, None)
 
             parameter = {
                 sw.name: prop,
@@ -345,6 +346,8 @@ class SwaggerV3Generator(SwaggerGenerator):
                 parameter[sw.explode] = explode
             if description is not None:
                 parameter[sw.description] = description
+            if style is not None:
+                parameter[sw.style] = style
 
             parameters.append(parameter)
 

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -166,7 +166,12 @@ class TestConverterRegistry(TestCase):
             ),
             (
                 CommaSeparatedList(m.fields.Integer()),
-                {"type": "array", "items": {"type": "integer"}, "style": "simple"},
+                {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "style": "form",
+                    "explode": False,
+                },
             ),
         ]:
 


### PR DESCRIPTION
I generated a swaggerv3 client of one of our repos, copy pasted it here https://editor.swagger.io/ and noticed there were some validation errors. The fix requires 2 steps:

1. `style` needs to be defined at the `parameter` level - move it out of the `schema` level (this was the root cause of the validation error). example error here: 

```
Structural error at paths./v1/<schema_name>
should NOT have additional properties
additionalProperty: style
```

2. after doing that, I got a different validation error because the value of `style: simple` was invalid. basically the way we want to handle a CommaSeparatedList is to format a *query param* like this: `filter[name]=abc123,def567`. the correct style we need to use here is `style: form, explode: False` as discussed here https://swagger.io/docs/specification/serialization/ for query params. `style: simple` is actually for path parameters which would be something like `/v1/accounts/abc123,def567` which (as I understand it) is not the use case for `CommaSeparatedList`.

example error here:

```
Structural error at paths./v1/<parameter_name>.style
should be equal to one of the allowed values
allowedValues: form, spaceDelimited, pipeDelimited, deepObject
```

 JIRA Tickets | 
 --------------| 
 [PJL-7600](https://jira.autodesk.com/browse/PJL-7600)|
