### PR TITLE
ACSBP3936 Add Enum converter for marshmallow.field.Enum

### DIFF
--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -642,8 +642,8 @@ class EnumerationConverter(FieldConverter):
 
     @sets_swagger_attr(sw.type_)
     def get_type(self, obj, context):
-        # Note: we don't (yet?) support mix-and-match between load_by and dump_by. Pick one.
-        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+        # Note: we don't (yet?) support mix-and-match between load_only and dump_only. Pick one.
+        if obj.by_value or (obj.load_only == obj.dump_only == LoadDumpOptions.value):
             # I'm going out on a limb and assuming your enum uses same type for all vals, else caveat emptor:
             value_type = type(next(iter(obj.enum)).value)
             if value_type is int:
@@ -657,7 +657,7 @@ class EnumerationConverter(FieldConverter):
 
     @sets_swagger_attr(sw.enum)
     def get_enum(self, obj, context):
-        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+        if obj.by_value or (obj.load_only == obj.dump_only == LoadDumpOptions.value):
             return [entry.value for entry in obj.enum]
         else:
             return [entry.name for entry in obj.enum]

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -637,6 +637,32 @@ class ConverterRegistry(object):
         )
 
 
+class EnumerationConverter(FieldConverter):
+    MARSHMALLOW_TYPE = m.fields.Enum
+
+    @sets_swagger_attr(sw.type_)
+    def get_type(self, obj, context):
+        # Note: we don't (yet?) support mix-and-match between load_by and dump_by. Pick one.
+        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+            # I'm going out on a limb and assuming your enum uses same type for all vals, else caveat emptor:
+            value_type = type(next(iter(obj.enum)).value)
+            if value_type is int:
+                return sw.integer
+            elif value_type is float:
+                return sw.number
+            else:
+                return sw.string
+        else:
+            return sw.string
+
+    @sets_swagger_attr(sw.enum)
+    def get_enum(self, obj, context):
+        if obj.by_value or (obj.load_by == obj.dump_by == LoadDumpOptions.value):
+            return [entry.value for entry in obj.enum]
+        else:
+            return [entry.name for entry in obj.enum]
+
+
 class EnumConverter(FieldConverter):
     MARSHMALLOW_TYPE = EnumField
 
@@ -678,6 +704,7 @@ def _common_converters():
         BooleanConverter(),
         DateConverter(),
         DateTimeConverter(),
+        EnumerationConverter(),
         FunctionConverter(),
         IntegerConverter(),
         LengthConverter(),

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -53,6 +53,14 @@ class TestConverterRegistry(TestCase):
             (m.fields.Integer(dump_only=True), {"type": "integer", "readOnly": True}),
             (m.fields.Integer(missing=lambda: 5), {"type": "integer"}),
             (
+                m.fields.Enum(StopLight),
+                {"enum": ["green", "yellow", "red"], "type": "string"},
+            ),
+            (
+                m.fields.Enum(StopLight, by_value=True),
+                {"enum": [1, 2, 3], "type": "integer"},
+            ),
+            (
                 me.EnumField(StopLight),
                 {"enum": ["green", "yellow", "red"], "type": "string"},
             ),


### PR DESCRIPTION
Marshmallow 2 didn't have a built-in for Enums. This adds a swagger converter and tests.

We could also remove the old converter and cut a new major release, if desired.

 JIRA Tickets | 
 --------------| 
 [ACSBP-3936](https://jira.autodesk.com/browse/ACSBP-3936)|
