### PR TITLE
ACSBP-4025: Update deprecated calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,10 @@ repos:
   # NOTE: it is not recommended to use mutable revs e.g. "stable" - run pre-commit autoupdate instead
   # ref: https://github.com/ambv/black/issues/420
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.7
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
-      language_version: python3.7

--- a/docs/quickstart/basics.rst
+++ b/docs/quickstart/basics.rst
@@ -93,7 +93,7 @@ Query String Validation
 .. code-block:: python
 
    class GetTodosSchema(RequestSchema):
-       exclude_completed = fields.String(missing=False)
+       exclude_completed = fields.String(load_default="")
 
 
    @registry.handles(

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -303,12 +303,12 @@ class FieldConverter(MarshmallowConverter):
     @sets_swagger_attr(sw.default)
     def get_default(self, obj, context):
         if (
-            obj.missing is not m.missing
+            obj.load_default is not m.missing
             # Marshmallow accepts a callable for the default. This is tricky
             # to handle, so let's just ignore this for now.
-            and not callable(obj.missing)
+            and not callable(obj.load_default)
         ):
-            return obj.missing
+            return obj.load_default
         else:
             return UNSET
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ exclude = '''
 )/
 '''
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error"
+]
+
 [build-system]
 requires = [
     "setuptools >= 35.0.2",

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 
 # packages required for local development and testing
 development = [
-    "black==22.3.0",
+    "black==23.3.0",
     "bumpversion==0.5.3",
     "click>=8.1.3,<9.0.0",
-    "flake8==4.0.1",
+    "flake8==6.0.0",
     "gitchangelog>=3.0.4,<4.0.0",
     "jsonschema==3.0.2",
     "marshmallow-objects~=2.3",

--- a/tests/swagger_generation/registries/exploded_query_string.py
+++ b/tests/swagger_generation/registries/exploded_query_string.py
@@ -14,7 +14,7 @@ swagger_v3_generator = SwaggerV3Generator()
 
 class ExplodedQueryStringSchema(RequestSchema):
     foos = QueryParamList(
-        marshmallow.fields.String(), required=True, description="foo string"
+        marshmallow.fields.String(), required=True, metadata={"description": "foo string"}
     )
 
 

--- a/tests/swagger_generation/registries/exploded_query_string.py
+++ b/tests/swagger_generation/registries/exploded_query_string.py
@@ -14,7 +14,9 @@ swagger_v3_generator = SwaggerV3Generator()
 
 class ExplodedQueryStringSchema(RequestSchema):
     foos = QueryParamList(
-        marshmallow.fields.String(), required=True, metadata={"description": "foo string"}
+        marshmallow.fields.String(),
+        required=True,
+        metadata={"description": "foo string"},
     )
 
 

--- a/tests/swagger_generation/registries/hidden_api.py
+++ b/tests/swagger_generation/registries/hidden_api.py
@@ -58,7 +58,7 @@ def get_foo(foo_uid):
     method="PATCH",
     response_body_schema={200: FooSchema()},
     request_body_schema=FooUpdateSchema(),
-    authenticator=authenticator,
+    authenticators=[authenticator],
 )
 def update_foo(foo_uid):
     pass
@@ -70,7 +70,7 @@ def update_foo(foo_uid):
     rule="/foo_list",
     method="GET",
     response_body_schema={200: FooSchema(many=True)},
-    authenticator=None,  # Override the default!
+    authenticators=None,  # Override the default!
     hidden=True,
 )
 def list_foos():
@@ -82,7 +82,7 @@ def list_foos():
     method="GET",
     response_body_schema={200: NestedFoosSchema()},
     query_string_schema=NameAndOtherSchema(),
-    authenticator=None,  # Override the default!
+    authenticators=None,  # Override the default!
 )
 def nested_foos():
     pass

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -1,4 +1,5 @@
 import marshmallow as m
+import pytest
 
 from flask_rebar import Rebar
 from flask_rebar import HeaderApiKeyAuthenticator
@@ -52,38 +53,39 @@ def get_foo(foo_uid):
     pass
 
 
-@registry.handles(
-    rule="/foos/<foo_uid>",
-    method="PATCH",
-    response_body_schema={200: FooSchema()},
-    request_body_schema=FooUpdateSchema(),
-    authenticator=authenticator,
-)
-def update_foo(foo_uid):
-    pass
+with pytest.warns(FutureWarning):  # authenticator kwarg is deprecating
+    @registry.handles(
+        rule="/foos/<foo_uid>",
+        method="PATCH",
+        response_body_schema={200: FooSchema()},
+        request_body_schema=FooUpdateSchema(),
+        authenticator=authenticator,
+    )
+    def update_foo(foo_uid):
+        pass
 
 
-# Test using Schema(many=True) without using a nested Field.
-# https://github.com/plangrid/flask-rebar/issues/41
-@registry.handles(
-    rule="/foo_list",
-    method="GET",
-    response_body_schema={200: FooSchema(many=True)},
-    authenticator=None,  # Override the default!
-)
-def list_foos():
-    pass
+    # Test using Schema(many=True) without using a nested Field.
+    # https://github.com/plangrid/flask-rebar/issues/41
+    @registry.handles(
+        rule="/foo_list",
+        method="GET",
+        response_body_schema={200: FooSchema(many=True)},
+        authenticator=None,  # Override the default!
+    )
+    def list_foos():
+        pass
 
 
-@registry.handles(
-    rule="/foos",
-    method="GET",
-    response_body_schema={200: NestedFoosSchema()},
-    query_string_schema=NameAndOtherSchema(),
-    authenticator=None,  # Override the default!
-)
-def nested_foos():
-    pass
+    @registry.handles(
+        rule="/foos",
+        method="GET",
+        response_body_schema={200: NestedFoosSchema()},
+        query_string_schema=NameAndOtherSchema(),
+        authenticator=None,  # Override the default!
+    )
+    def nested_foos():
+        pass
 
 
 @registry.handles(rule="/tagged_foos", tags=["bar", "baz"])

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -54,6 +54,7 @@ def get_foo(foo_uid):
 
 
 with pytest.warns(FutureWarning):  # authenticator kwarg is deprecating
+
     @registry.handles(
         rule="/foos/<foo_uid>",
         method="PATCH",
@@ -63,7 +64,6 @@ with pytest.warns(FutureWarning):  # authenticator kwarg is deprecating
     )
     def update_foo(foo_uid):
         pass
-
 
     # Test using Schema(many=True) without using a nested Field.
     # https://github.com/plangrid/flask-rebar/issues/41
@@ -75,7 +75,6 @@ with pytest.warns(FutureWarning):  # authenticator kwarg is deprecating
     )
     def list_foos():
         pass
-
 
     @registry.handles(
         rule="/foos",

--- a/tests/swagger_generation/registries/marshmallow_objects.py
+++ b/tests/swagger_generation/registries/marshmallow_objects.py
@@ -59,7 +59,7 @@ def get_foo(foo_uid):
     method="PATCH",
     response_body_schema={200: FooModel},
     request_body_schema=FooUpdateModel,
-    authenticator=authenticator,
+    authenticators=[authenticator],
 )
 def update_foo(foo_uid):
     pass
@@ -70,7 +70,7 @@ def update_foo(foo_uid):
     method="GET",
     response_body_schema={200: NestedFoosModel},
     query_string_schema=NameAndOtherModel,
-    authenticator=None,  # Override the default!
+    authenticators=None,  # Override the default!
 )
 def nested_foos():
     pass

--- a/tests/swagger_generation/registries/multiple_authenticators.py
+++ b/tests/swagger_generation/registries/multiple_authenticators.py
@@ -249,7 +249,7 @@ def list_foos():
     method="GET",
     response_body_schema={200: NestedFoosSchema()},
     query_string_schema=NameAndOtherSchema(),
-    authenticator=None,  # Override the default!
+    authenticators=None,  # Override the default!
 )
 def nested_foos():
     pass

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -73,7 +73,7 @@ class TestConverterRegistry(TestCase):
                 {"type": "array", "items": {"type": "integer"}},
             ),
             (
-                m.fields.Integer(description="blam!"),
+                m.fields.Integer(metadata={"description": "blam!"}),
                 {"type": "integer", "description": "blam!"},
             ),
             (
@@ -122,14 +122,17 @@ class TestConverterRegistry(TestCase):
             ),
             (m.fields.Dict(), {"type": "object"}),
             (
-                m.fields.Method(serialize="x", deserialize="y", swagger_type="integer"),
+                m.fields.Method(
+                    serialize="x", deserialize="y",
+                    metadata={"swagger_type": "integer"}
+                ),
                 {"type": "integer"},
             ),
             (
                 m.fields.Function(
                     serialize=lambda _: _,
                     deserialize=lambda _: _,
-                    swagger_type="string",
+                    metadata={"swagger_type": "string"},
                 ),
                 {"type": "string"},
             ),

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -124,8 +124,7 @@ class TestConverterRegistry(TestCase):
             (m.fields.Dict(), {"type": "object"}),
             (
                 m.fields.Method(
-                    serialize="x", deserialize="y",
-                    metadata={"swagger_type": "integer"}
+                    serialize="x", deserialize="y", metadata={"swagger_type": "integer"}
                 ),
                 {"type": "integer"},
             ),
@@ -369,6 +368,7 @@ class TestConverterRegistry(TestCase):
         # and passing "self" as a string is deprecated
         # but that doesn't work in < 3.3, so until 4.x we'll keep supporting/testing with "self"
         with pytest.deprecated_call():
+
             class Foo(m.Schema):
                 a = m.fields.Nested("self", exclude=("a",))
                 b = m.fields.Integer()

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -49,9 +49,9 @@ class TestConverterRegistry(TestCase):
             (m.fields.URL(), {"type": "string"}),
             (m.fields.Email(), {"type": "string"}),
             (m.fields.Constant("foo"), {"enum": ["foo"], "default": "foo"}),
-            (m.fields.Integer(missing=5), {"type": "integer", "default": 5}),
+            (m.fields.Integer(load_default=5), {"type": "integer", "default": 5}),
             (m.fields.Integer(dump_only=True), {"type": "integer", "readOnly": True}),
-            (m.fields.Integer(missing=lambda: 5), {"type": "integer"}),
+            (m.fields.Integer(load_default=lambda: 5), {"type": "integer"}),
             (
                 EnumField(StopLight),
                 {"enum": ["green", "yellow", "red"], "type": "string"},

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -70,15 +70,11 @@ class FooListModel(mo.Model):
 
 
 class HeadersSchema(m.Schema):
-    name = set_data_key(
-        field=m.fields.String(required=True), key="x-name"
-    )
+    name = set_data_key(field=m.fields.String(required=True), key="x-name")
 
 
 class HeadersModel(mo.Model):
-    name = set_data_key(
-        field=mo.fields.String(required=True), key="x-name"
-    )
+    name = set_data_key(field=mo.fields.String(required=True), key="x-name")
 
 
 class MeSchema(m.Schema):

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -71,13 +71,13 @@ class FooListModel(mo.Model):
 
 class HeadersSchema(m.Schema):
     name = set_data_key(
-        field=m.fields.String(load_from="x-name", required=True), key="x-name"
+        field=m.fields.String(required=True), key="x-name"
     )
 
 
 class HeadersModel(mo.Model):
     name = set_data_key(
-        field=mo.fields.String(load_from="x-name", required=True), key="x-name"
+        field=mo.fields.String(required=True), key="x-name"
     )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -41,7 +41,7 @@ class RequireOnDumpMixinSchema(NoRequireOnDumpMixinSchema, RequireOnDumpMixin):
 
 
 class InnerNested(Schema, RequireOnDumpMixin):
-    inner_dump_only = fields.String(default="Inner dump-only", dump_only=True)
+    inner_dump_only = fields.String(dump_default="Inner dump-only", dump_only=True)
     inner_nested = fields.Nested(RequireOnDumpMixinSchema)
     inner_nested_dump_only = fields.Nested(RequireOnDumpMixinSchema, dump_only=True)
     inner_nested_list = fields.List(fields.Nested(RequireOnDumpMixinSchema))
@@ -49,7 +49,7 @@ class InnerNested(Schema, RequireOnDumpMixin):
 
 
 class OuterNested(Schema, RequireOnDumpMixin):
-    outer_dump_only = fields.String(default="Outer dump-only", dump_only=True)
+    outer_dump_only = fields.String(dump_default="Outer dump-only", dump_only=True)
     nested = fields.Nested(InnerNested)
     nested_list = fields.List(fields.Nested(InnerNested))
 


### PR DESCRIPTION
Maintenance
- Update usages of deprecated Marshmallow "missing" field property to "load_default"
- Update tests usages of deprecated Marshmallow arguments.
- Update tests usages of deprecate Rebar 'authenticator' arguement.
- Update test configuration to block when unexpected warnings are thrown in the test suite.
   - Use pytest.warns or pytest.deprecated_call when warnings are expected to be thrown.

 JIRA Tickets | 
 --------------| 
 [ACSBP-4025](https://jira.autodesk.com/browse/ACSBP-4025)|
