### PR TITLE
update all dev dependencies to latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   # NOTE: it is not recommended to use mutable revs e.g. "stable" - run pre-commit autoupdate instead
   # ref: https://github.com/ambv/black/issues/420
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     - id: black
   - repo: https://github.com/pycqa/flake8

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,19 @@ from setuptools import setup, find_packages
 
 # packages required for local development and testing
 development = [
-    "black==23.3.0",
-    "bumpversion==0.5.3",
+    "black==23.7.0",
+    "bumpversion==0.6.0",
     "click>=8.1.3,<9.0.0",
     "flake8==6.0.0",
     "gitchangelog>=3.0.4,<4.0.0",
-    "jsonschema==3.0.2",
+    "jsonschema==4.18.4",
     "marshmallow-objects~=2.3",
     "parametrize==0.1.1",
     "pre-commit>=1.14.4",
-    "pytest~=6.2",
+    "pytest~=7.4",
     "pytest-order~=1.0",
-    "Sphinx==1.7.0",
-    "sphinx_rtd_theme==0.2.4",
+    "Sphinx>=6.0.0,<7.0.0",
+    "sphinx_rtd_theme==1.2.2",
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
I set up this repo from scratch using python 3.11 (which I think is meant to be supported). It turns out that the pinned version of jsonschema is incompatible with python 3.11 and errors out when you run unit tests, at least on my laptop (I guess the tests somehow work on CI/CD?). I updated the dev dependencies and the tests pass (no needed code changes).