### PR TITLE
fix syntax in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Installation
 
 
 Replacing static swagger-ui files
--------------
+---------------------------------
 
 If you'd like to replace swagger-ui's static files (`flask_rebar/swagger_ui/static`) with those of the latest release,
 run the following from the root of the project.


### PR DESCRIPTION
PyPI rendering fails for readme and won't let me release a new version