### PR TITLE
allow specifying swagger documents for path converters

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.11
   install:
     - method: pip
       path: .

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -28,6 +28,12 @@ Authenticator Objects
    :members:
 
 
+Base Generation
+---------------
+
+.. autoclass:: flask_rebar.swagger_generation.swagger_generator_base.SwaggerGenerator
+   :members:
+
 Swagger V2 Generation
 ---------------------
 

--- a/examples/todo/todo/app.py
+++ b/examples/todo/todo/app.py
@@ -11,6 +11,8 @@ from flask_rebar import (
 )
 from flask_rebar.validation import RequestSchema, ResponseSchema
 
+from .converters import TodoTypeConverter
+
 
 rebar = Rebar()
 
@@ -30,6 +32,10 @@ registry = rebar.create_handler_registry(
 
 def create_app():
     app = Flask(__name__)
+
+    # register new type for url mapping
+    app.url_map.converters["todo_types"] = TodoTypeConverter
+    generator.register_flask_converter_to_swagger_type("todo_types", TodoTypeConverter)
 
     authenticator = HeaderApiKeyAuthenticator(header="X-MyApp-Key")
     # The HeaderApiKeyAuthenticator does super simple authentication, designed for

--- a/examples/todo/todo/converters.py
+++ b/examples/todo/todo/converters.py
@@ -1,0 +1,28 @@
+import enum
+
+from flask_rebar.swagger_generation import swagger_words as sw
+from werkzeug.routing import BaseConverter
+from werkzeug.routing import ValidationError
+
+
+class TodoType(str, enum.Enum):
+    user = "user"
+    group = "group"
+
+
+class TodoTypeConverter(BaseConverter):
+    def to_python(self, value):
+        try:
+            return TodoType(value)
+        except ValueError:
+            raise ValidationError()
+
+    def to_url(self, obj):
+        return obj.value
+
+    @staticmethod
+    def to_swagger():
+        return {
+            sw.type_: sw.string,
+            sw.enum: [t.value for t in TodoType],
+        }

--- a/examples/todo/todo/schemas.py
+++ b/examples/todo/todo/schemas.py
@@ -34,7 +34,7 @@ class TodoSchema(ResponseSchema):
     id = fields.Integer(required=True)
     complete = fields.Boolean(required=True)
     description = fields.String(required=True)
-    type = fields.Enum(TodoType, required=True)
+    type = EnumField(TodoType, required=True)
 
 
 class TodoResourceSchema(ResponseSchema):

--- a/examples/todo/todo/schemas.py
+++ b/examples/todo/todo/schemas.py
@@ -5,10 +5,13 @@
 from flask_rebar.validation import RequestSchema, ResponseSchema
 from marshmallow import fields, pre_dump, pre_load
 
+from .converters import TodoType
+
 
 class CreateTodoSchema(RequestSchema):
     complete = fields.Boolean(required=True)
     description = fields.String(required=True)
+    type = fields.Enum(TodoType, load_default=TodoType.user)
 
 
 class UpdateTodoSchema(CreateTodoSchema):
@@ -30,6 +33,7 @@ class TodoSchema(ResponseSchema):
     id = fields.Integer(required=True)
     complete = fields.Boolean(required=True)
     description = fields.String(required=True)
+    type = fields.Enum(TodoType, required=True)
 
 
 class TodoResourceSchema(ResponseSchema):

--- a/examples/todo/todo/schemas.py
+++ b/examples/todo/todo/schemas.py
@@ -3,6 +3,7 @@
 # data, and to automatically generate a Swagger specification.
 
 from flask_rebar.validation import RequestSchema, ResponseSchema
+from flask_rebar.swagger_generation.marshmallow_to_swagger import EnumField
 from marshmallow import fields, pre_dump, pre_load
 
 from .converters import TodoType
@@ -11,7 +12,7 @@ from .converters import TodoType
 class CreateTodoSchema(RequestSchema):
     complete = fields.Boolean(required=True)
     description = fields.String(required=True)
-    type = fields.Enum(TodoType, load_default=TodoType.user)
+    type = EnumField(TodoType, load_default=TodoType.user)
 
 
 class UpdateTodoSchema(CreateTodoSchema):

--- a/flask_rebar/swagger_generation/swagger_generator_base.py
+++ b/flask_rebar/swagger_generation/swagger_generator_base.py
@@ -174,4 +174,48 @@ class SwaggerGenerator(SwaggerGeneratorI):
         return self._open_api_version
 
     def register_flask_converter_to_swagger_type(self, flask_converter, swagger_type):
+        """
+        Register a converter for a type in flask to a swagger type.
+
+        This can be used to alter the types of objects that already exist or add
+        swagger types to objects that are added to the base flask configuration.
+
+        For example, when adding custom path types to the Flask url_map, a
+        converter can be added for customizing the swagger type.
+
+        .. code-block:: python
+
+            import enum
+
+            from flask_rebar.swagger_generation import swagger_words as sw
+
+
+            class TodoType(str, enum.Enum):
+                user = "user"
+                group = "group"
+
+
+            class TodoTypeConverter:
+
+                @staticmethod
+                def to_swagger():
+                    return {
+                        sw.type_: sw.string,
+                        sw.enum: [t.value for t in TodoType],
+                    }
+
+            @registry.handles(
+                rule="/todos/<todo_type:type_>",
+            )
+            def get_todos_by_type(type_):
+                ...
+
+            generator.register_flask_converter_to_swagger_type(
+                flask_converter="todo_type",
+                swagger_type=TodoTypeConverter,
+            )
+        
+        With the above example, when something is labeled as a ``todo_type`` in
+        a path. The correct swagger can be returned.
+        """
         self.flask_converters_to_swagger_types[flask_converter] = swagger_type

--- a/flask_rebar/swagger_generation/swagger_generator_base.py
+++ b/flask_rebar/swagger_generation/swagger_generator_base.py
@@ -214,7 +214,7 @@ class SwaggerGenerator(SwaggerGeneratorI):
                 flask_converter="todo_type",
                 swagger_type=TodoTypeConverter,
             )
-        
+
         With the above example, when something is labeled as a ``todo_type`` in
         a path. The correct swagger can be returned.
         """

--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -190,15 +190,18 @@ class SwaggerV2Generator(SwaggerGenerator):
                 path_definitions[spec_path] = path_definition = {}
 
             if path_args:
-                path_params = [
-                    {
+                path_params = []
+                for path_arg in path_args:
+                    next_param = {
                         sw.name: path_arg.name,
                         sw.required: True,
                         sw.in_: sw.path,
-                        sw.type_: self.flask_converters_to_swagger_types[path_arg.type],
                     }
-                    for path_arg in path_args
-                ]
+                    if isinstance(converter := self.flask_converters_to_swagger_types[path_arg.type], str):
+                        next_param[sw.type_] = converter
+                    else:
+                        next_param.update(converter.to_swagger())
+                    path_params.append(next_param)
 
                 # We have to check for an ugly case here. If different Flask
                 # paths that map to the same Swagger path use different URL

--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -197,15 +197,15 @@ class SwaggerV2Generator(SwaggerGenerator):
                         sw.required: True,
                         sw.in_: sw.path,
                     }
-                    if isinstance(
+                    if hasattr(
                         converter := self.flask_converters_to_swagger_types[
                             path_arg.type
                         ],
-                        str,
+                        "to_swagger",
                     ):
-                        next_param[sw.type_] = converter
-                    else:
                         next_param.update(converter.to_swagger())
+                    else:
+                        next_param[sw.type_] = converter
                     path_params.append(next_param)
 
                 # We have to check for an ugly case here. If different Flask

--- a/flask_rebar/swagger_generation/swagger_generator_v2.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v2.py
@@ -197,7 +197,12 @@ class SwaggerV2Generator(SwaggerGenerator):
                         sw.required: True,
                         sw.in_: sw.path,
                     }
-                    if isinstance(converter := self.flask_converters_to_swagger_types[path_arg.type], str):
+                    if isinstance(
+                        converter := self.flask_converters_to_swagger_types[
+                            path_arg.type
+                        ],
+                        str,
+                    ):
                         next_param[sw.type_] = converter
                     else:
                         next_param.update(converter.to_swagger())

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -153,20 +153,20 @@ class SwaggerV3Generator(SwaggerGenerator):
                 path_definitions[spec_path] = path_definition = {}
 
             if path_args:
-                path_params = [
-                    {
+                path_params = []
+                for path_arg in path_args:
+                    next_param = {
                         sw.name: path_arg.name,
                         sw.required: True,
                         sw.in_: sw.path,
                         sw.style: sw.simple,
-                        sw.schema: {
-                            sw.type_: self.flask_converters_to_swagger_types[
-                                path_arg.type
-                            ]
-                        },
+                        sw.schema: {}
                     }
-                    for path_arg in path_args
-                ]
+                    if isinstance(converter := self.flask_converters_to_swagger_types[path_arg.type], str):
+                        next_param[sw.schema][sw.type_] = converter
+                    else:
+                        next_param[sw.schema].update(converter.to_swagger())
+                    path_params.append(next_param)
 
                 # We have to check for an ugly case here. If different Flask
                 # paths that map to the same Swagger path use different URL

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -160,9 +160,14 @@ class SwaggerV3Generator(SwaggerGenerator):
                         sw.required: True,
                         sw.in_: sw.path,
                         sw.style: sw.simple,
-                        sw.schema: {}
+                        sw.schema: {},
                     }
-                    if isinstance(converter := self.flask_converters_to_swagger_types[path_arg.type], str):
+                    if isinstance(
+                        converter := self.flask_converters_to_swagger_types[
+                            path_arg.type
+                        ],
+                        str,
+                    ):
                         next_param[sw.schema][sw.type_] = converter
                     else:
                         next_param[sw.schema].update(converter.to_swagger())

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -162,15 +162,15 @@ class SwaggerV3Generator(SwaggerGenerator):
                         sw.style: sw.simple,
                         sw.schema: {},
                     }
-                    if isinstance(
+                    if hasattr(
                         converter := self.flask_converters_to_swagger_types[
                             path_arg.type
                         ],
-                        str,
+                        "to_swagger",
                     ):
-                        next_param[sw.schema][sw.type_] = converter
-                    else:
                         next_param[sw.schema].update(converter.to_swagger())
+                    else:
+                        next_param[sw.schema][sw.type_] = converter
                     path_params.append(next_param)
 
                 # We have to check for an ugly case here. If different Flask

--- a/tests/examples/test_todo.py
+++ b/tests/examples/test_todo.py
@@ -77,14 +77,30 @@ class TestTodoApp(unittest.TestCase):
             headers={"X-MyApp-Key": "my-api-key", "Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json["data"][0], {"id": 1, "complete": True, "description": "Find product market fit", "type": "user"})
+        self.assertEqual(
+            resp.json["data"][0],
+            {
+                "id": 1,
+                "complete": True,
+                "description": "Find product market fit",
+                "type": "user",
+            },
+        )
 
         resp = self.app.test_client().get(
             "/todos/user",
             headers={"X-MyApp-Key": "my-api-key", "Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json["data"][0], {"id": 1, "complete": True, "description": "Find product market fit", "type": "user"})
+        self.assertEqual(
+            resp.json["data"][0],
+            {
+                "id": 1,
+                "complete": True,
+                "description": "Find product market fit",
+                "type": "user",
+            },
+        )
 
         resp = self.app.test_client().get(
             "/todos/group",

--- a/tests/examples/test_todo.py
+++ b/tests/examples/test_todo.py
@@ -77,3 +77,18 @@ class TestTodoApp(unittest.TestCase):
             headers={"X-MyApp-Key": "my-api-key", "Content-Type": "application/json"},
         )
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json["data"][0], {"id": 1, "complete": True, "description": "Find product market fit", "type": "user"})
+
+        resp = self.app.test_client().get(
+            "/todos/user",
+            headers={"X-MyApp-Key": "my-api-key", "Content-Type": "application/json"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json["data"][0], {"id": 1, "complete": True, "description": "Find product market fit", "type": "user"})
+
+        resp = self.app.test_client().get(
+            "/todos/group",
+            headers={"X-MyApp-Key": "my-api-key", "Content-Type": "application/json"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json["data"])

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -12,13 +12,9 @@ registry = rebar.create_handler_registry()
 
 
 class UUIDPathConverter:
-
     @staticmethod
     def to_swagger():
-        return {
-            sw.type_: sw.string,
-            sw.format_: sw.uuid
-        }
+        return {sw.type_: sw.string, sw.format_: sw.uuid}
 
 
 swagger_v2_generator = SwaggerV2Generator()
@@ -124,7 +120,13 @@ EXPECTED_SWAGGER_V2 = {
     "paths": {
         "/foos/{foo_uid}": {
             "parameters": [
-                {"name": "foo_uid", "in": "path", "required": True, "type": "string", "format": "uuid"}
+                {
+                    "name": "foo_uid",
+                    "in": "path",
+                    "required": True,
+                    "type": "string",
+                    "format": "uuid",
+                }
             ],
             "get": {
                 "operationId": "get_foo",

--- a/tests/swagger_generation/registries/legacy.py
+++ b/tests/swagger_generation/registries/legacy.py
@@ -5,12 +5,26 @@ from flask_rebar import Rebar
 from flask_rebar import HeaderApiKeyAuthenticator
 from flask_rebar import compat
 from flask_rebar.swagger_generation import SwaggerV2Generator, SwaggerV3Generator
+from flask_rebar.swagger_generation import swagger_words as sw
 
 rebar = Rebar()
 registry = rebar.create_handler_registry()
 
+
+class UUIDPathConverter:
+
+    @staticmethod
+    def to_swagger():
+        return {
+            sw.type_: sw.string,
+            sw.format_: sw.uuid
+        }
+
+
 swagger_v2_generator = SwaggerV2Generator()
+swagger_v2_generator.register_flask_converter_to_swagger_type("uuid", UUIDPathConverter)
 swagger_v3_generator = SwaggerV3Generator()
+swagger_v3_generator.register_flask_converter_to_swagger_type("uuid", UUIDPathConverter)
 
 authenticator = HeaderApiKeyAuthenticator(header="x-auth")
 default_authenticator = HeaderApiKeyAuthenticator(header="x-another", name="default")
@@ -43,7 +57,7 @@ class NameAndOtherSchema(m.Schema):
 
 
 @registry.handles(
-    rule="/foos/<uuid_string:foo_uid>",
+    rule="/foos/<uuid:foo_uid>",
     method="GET",
     response_body_schema={200: FooSchema()},
     headers_schema=HeaderSchema(),
@@ -56,7 +70,7 @@ def get_foo(foo_uid):
 with pytest.warns(FutureWarning):  # authenticator kwarg is deprecating
 
     @registry.handles(
-        rule="/foos/<foo_uid>",
+        rule="/foos/<uuid:foo_uid>",
         method="PATCH",
         response_body_schema={200: FooSchema()},
         request_body_schema=FooUpdateSchema(),
@@ -110,7 +124,7 @@ EXPECTED_SWAGGER_V2 = {
     "paths": {
         "/foos/{foo_uid}": {
             "parameters": [
-                {"name": "foo_uid", "in": "path", "required": True, "type": "string"}
+                {"name": "foo_uid", "in": "path", "required": True, "type": "string", "format": "uuid"}
             ],
             "get": {
                 "operationId": "get_foo",
@@ -309,7 +323,7 @@ EXPECTED_SWAGGER_V3 = expected_swagger = {
                     "in": "path",
                     "required": True,
                     "style": "simple",
-                    "schema": {"type": "string"},
+                    "schema": {"type": "string", "format": "uuid"},
                 }
             ],
             "get": {


### PR DESCRIPTION
without much changing elsewhere, this allows us to set enum types for custom path converters in flask.

for example: `/v1/preferences/<preference_type:scope>` where scope could be `user`, `project`, or `account`. We can define an object with a `to_swagger` function as part of the [Flask Converter](https://flask.palletsprojects.com/en/2.3.x/api/#flask.Flask.url_map) that is defined.