### PR TITLE
fix: Prevent hidden methods from being included in schema

### DIFF
--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -180,6 +180,9 @@ class SwaggerV3Generator(SwaggerGenerator):
                 path_definition[sw.parameters] = path_params
 
             for method, d in methods.items():
+                if d.hidden:
+                    continue
+
                 responses_definition = {
                     sw.default: self._get_response_definition(
                         self.default_response_schema

--- a/flask_rebar/swagger_generation/swagger_generator_v3.py
+++ b/flask_rebar/swagger_generation/swagger_generator_v3.py
@@ -180,7 +180,7 @@ class SwaggerV3Generator(SwaggerGenerator):
                 path_definition[sw.parameters] = path_params
 
             for method, d in methods.items():
-                if d.hidden:
+                if not self.include_hidden and d.hidden:
                     continue
 
                 responses_definition = {

--- a/tests/swagger_generation/registries/hidden_api.py
+++ b/tests/swagger_generation/registries/hidden_api.py
@@ -63,12 +63,13 @@ def get_foo(foo_uid):
 def update_foo(foo_uid):
     pass
 
+
 @registry.handles(
     rule="/foos/<foo_uid>",
     method="DELETE",
     response_body_schema={200: FooSchema()},
     authenticators=[authenticator],
-    hidden=True
+    hidden=True,
 )
 def delete_foo(foo_uid):
     pass
@@ -124,26 +125,18 @@ EXPECTED_SWAGGER_V2 = {
                 {"name": "foo_uid", "in": "path", "required": True, "type": "string"}
             ],
             "delete": {
-              "operationId": "delete_foo",
-              "responses": {
-                "200": {
-                  "description": "Foo",
-                  "schema": {
-                    "$ref": "#/definitions/Foo"
-                  }
+                "operationId": "delete_foo",
+                "responses": {
+                    "200": {
+                        "description": "Foo",
+                        "schema": {"$ref": "#/definitions/Foo"},
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {"$ref": "#/definitions/Error"},
+                    },
                 },
-                "default": {
-                  "description": "Error",
-                  "schema": {
-                    "$ref": "#/definitions/Error"
-                  }
-                }
-              },
-              "security": [
-                {
-                  "sharedSecret": []
-                }
-              ]
+                "security": [{"sharedSecret": []}],
             },
             "get": {
                 "operationId": "get_foo",
@@ -524,34 +517,26 @@ SWAGGER_V3_WITH_HIDDEN = expected_swagger = {
                 }
             ],
             "delete": {
-              "operationId": "delete_foo",
-              "responses": {
-                "200": {
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Foo"
-                      }
-                    }
-                  },
-                  "description": "Foo"
+                "operationId": "delete_foo",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Foo"}
+                            }
+                        },
+                        "description": "Foo",
+                    },
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                        "description": "Error",
+                    },
                 },
-                "default": {
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Error"
-                      }
-                    }
-                  },
-                  "description": "Error"
-                }
-              },
-              "security": [
-                {
-                  "sharedSecret": []
-                }
-              ]
+                "security": [{"sharedSecret": []}],
             },
             "get": {
                 "operationId": "get_foo",

--- a/tests/swagger_generation/registries/hidden_api.py
+++ b/tests/swagger_generation/registries/hidden_api.py
@@ -63,6 +63,16 @@ def get_foo(foo_uid):
 def update_foo(foo_uid):
     pass
 
+@registry.handles(
+    rule="/foos/<foo_uid>",
+    method="DELETE",
+    response_body_schema={200: FooSchema()},
+    authenticators=[authenticator],
+    hidden=True
+)
+def delete_foo(foo_uid):
+    pass
+
 
 # Test using Schema(many=True) without using a nested Field.
 # https://github.com/plangrid/flask-rebar/issues/41
@@ -113,6 +123,28 @@ EXPECTED_SWAGGER_V2 = {
             "parameters": [
                 {"name": "foo_uid", "in": "path", "required": True, "type": "string"}
             ],
+            "delete": {
+              "operationId": "delete_foo",
+              "responses": {
+                "200": {
+                  "description": "Foo",
+                  "schema": {
+                    "$ref": "#/definitions/Foo"
+                  }
+                },
+                "default": {
+                  "description": "Error",
+                  "schema": {
+                    "$ref": "#/definitions/Error"
+                  }
+                }
+              },
+              "security": [
+                {
+                  "sharedSecret": []
+                }
+              ]
+            },
             "get": {
                 "operationId": "get_foo",
                 "description": "helpful description",
@@ -491,6 +523,36 @@ SWAGGER_V3_WITH_HIDDEN = expected_swagger = {
                     "schema": {"type": "string"},
                 }
             ],
+            "delete": {
+              "operationId": "delete_foo",
+              "responses": {
+                "200": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Foo"
+                      }
+                    }
+                  },
+                  "description": "Foo"
+                },
+                "default": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Error"
+                      }
+                    }
+                  },
+                  "description": "Error"
+                }
+              },
+              "security": [
+                {
+                  "sharedSecret": []
+                }
+              ]
+            },
             "get": {
                 "operationId": "get_foo",
                 "description": "helpful description",


### PR DESCRIPTION
**Summary of issue**:

APIs specified with `hidden=True` are included in the schema unless _all_ methods for the path are marked as `hidden=True`. For example, if we define two methods on the `/foos/<foo_uid>` path:

```python
@registry.handles(
    rule="/foos/<foo_uid>",
    method="PATCH",
)
def update_foo(foo_uid):
    pass

@registry.handles(
    rule="/foos/<foo_uid>",
    method="DELETE",
    hidden=True
)
def delete_foo(foo_uid):
    pass
```

The `DELETE` request will be included in the generated spec, due to the requirement for [all methods of the path](https://github.com/plangrid/flask-rebar/blob/6228a2410246e1a7e1f5feedb05b01fb591face0/flask_rebar/swagger_generation/swagger_generator_v3.py#L142-L145) to have `hidden=True` set.



**Summary of change**:

Update the generator to respect `hidden=True` on methods even if all methods for the path are not marked as `hidden=True`. 