### PR TITLE
add missing runtime dependencies

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -32,7 +32,12 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import ParamSpec
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import RequestRedirect

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -27,7 +27,12 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import ParamSpec
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 import marshmallow as m
 from marshmallow import Schema
 from marshmallow.validate import Range

--- a/flask_rebar/utils/deprecation.py
+++ b/flask_rebar/utils/deprecation.py
@@ -9,9 +9,14 @@
 """
 from __future__ import annotations
 import functools
+import sys
 import warnings
 from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, TypeVar, Union
-from typing_extensions import ParamSpec
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 from werkzeug.local import LocalProxy as module_property  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     "Flask>=1.0,<4",
     "marshmallow>=3.0,<4",
     "typing-extensions>=4.8,<5;python_version<'3.10'",
+    "Werkzeug>=2.2,<4",
 ]
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,12 @@ development = [
     "types-setuptools==68.0.0.3",
 ]
 
+install_requires = [
+    "Flask>=1.0,<4",
+    "marshmallow>=3.0,<4",
+    "typing-extensions>=4.8,<5",
+]
+
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
@@ -36,7 +42,7 @@ if __name__ == "__main__":
         package_data={"flask_rebar": ["py.typed"]},
         include_package_data=True,
         extras_require={"dev": development, "enum": ["marshmallow-enum~=1.5"]},
-        install_requires=["Flask>=1.0,<4", "marshmallow>=3.0,<4"],
+        install_requires=install_requires,
         url="https://github.com/plangrid/flask-rebar",
         classifiers=[
             "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ development = [
 install_requires = [
     "Flask>=1.0,<4",
     "marshmallow>=3.0,<4",
-    "typing-extensions>=4.8,<5",
+    "typing-extensions>=4.8,<5;python_version<'3.10'",
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
hi,

flask-rebar uses bits from dependent modules without declaring the proper dependency.

Full disclosure: I am not super fluent in python, so this might not be the python way of fixing this.

Only commit f73264ea5cf95865de439eb9f9a9441b921090c0 is strictly necessary, everything else should be considered rfc.

I started a fresh flask/flask-rebar project. Running the built-in development server of flask complained about imports from missing modules.

BR,
Valentin