### PR TITLE
Update pypa/gh-action-pypi-publish Tag to release/v1

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,6 +22,6 @@ jobs:
       run: |
         python -m pep517.build .
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
**Description of Issue:**
- Build and Publish workflow failing because master branch of pypa/gh-action-pypi-publish has been sunset

**Proposed Solution:**
- Update tag to `release/v1` as recommended here: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#-master-branch-sunset-