### PR TITLE
Bump Version: 3.2.0 → 3.2.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="3.2.0",
+        version="3.2.1",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",


### PR DESCRIPTION
Bump Version: 3.2.0 → 3.2.1

Changes: 
- Provide clear vulnerability reporting instructions 
- Fix test failures due to marshmallow depreciation warnings 
- Update why.rst 
- Add missing runtime dependencies 
- Update pypa/gh-action-pypi-publish tag to release/v1 