### PR TITLE
Fix schema flattener to support list-type `type` field introduced in OpenAPI 3.1

### DIFF
--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -143,9 +143,9 @@ def _flatten(
     # With OpenAPI 3.1, this will be a list of allowed types that includes sw.null if the field is nullable.
     schema_type: str | list[str] | None = schema.get(sw.type_)
     schema_types = []
-    if type(schema_type) is str:
+    if isinstance(schema_type, str):
         schema_types = [schema_type]
-    elif type(schema_type) is list:
+    elif isinstance(schema_type, list):
         schema_types = schema_type
 
     subschema_keyword = _get_subschema_keyword(schema)

--- a/flask_rebar/swagger_generation/generator_utils.py
+++ b/flask_rebar/swagger_generation/generator_utils.py
@@ -140,15 +140,22 @@ def flatten(schema: Dict[str, Any], base: str) -> Tuple[Dict[str, str], Dict[str
 def _flatten(
     schema: Dict[str, Any], definitions: Dict[str, Any], base: str
 ) -> Dict[str, str]:
-    schema_type = schema.get(sw.type_)
+    # With OpenAPI 3.1, this will be a list of allowed types that includes sw.null if the field is nullable.
+    schema_type: str | list[str] | None = schema.get(sw.type_)
+    schema_types = []
+    if type(schema_type) is str:
+        schema_types = [schema_type]
+    elif type(schema_type) is list:
+        schema_types = schema_type
+
     subschema_keyword = _get_subschema_keyword(schema)
 
-    if schema_type == sw.object_:
+    if sw.object_ in schema_types:
         properties = schema.get(sw.properties, {})
         for key, prop in properties.items():
             properties[key] = _flatten(schema=prop, definitions=definitions, base=base)
 
-    elif schema_type == sw.array:
+    elif sw.array in schema_types:
         schema[sw.items] = _flatten(
             schema=schema[sw.items], definitions=definitions, base=base
         )

--- a/tests/swagger_generation/test_generator_utils.py
+++ b/tests/swagger_generation/test_generator_utils.py
@@ -188,6 +188,47 @@ class TestFlatten(unittest.TestCase):
         self.assertEqual(schema, expected_schema)
         self.assertEqual(definitions, expected_definitions)
 
+    def test_flatten_creates_refs_when_type_is_list(self):
+        self.maxDiff = None
+        input_ = {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {"name": {"type": "string"}},
+                        "title": "NestedSchema",
+                        "type": "object",
+                    },
+                    "type": ["array", "null"],
+                },
+            },
+            "title": "ParentAllowNoneTrueSchema",
+            "type": "object",
+        }
+
+        expected_schema = {"$ref": "#/definitions/ParentAllowNoneTrueSchema"}
+
+        expected_definitions = {
+            "NestedSchema": {
+                "properties": {"name": {"type": "string"}},
+                "title": "NestedSchema",
+                "type": "object",
+            },
+            "ParentAllowNoneTrueSchema": {
+                "properties": {
+                    "data": {
+                        "items": {"$ref": "#/definitions/NestedSchema"},
+                        "type": ["array", "null"],
+                    }
+                },
+                "title": "ParentAllowNoneTrueSchema",
+                "type": "object",
+            },
+        }
+
+        schema, definitions = flatten(input_, base="#/definitions")
+        self.assertEqual(schema, expected_schema)
+        self.assertEqual(definitions, expected_definitions)
+
 
 class TestFormatPathForSwagger(unittest.TestCase):
     def test_format_path(self):

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -82,6 +82,18 @@ class MeSchema(m.Schema):
     user_name = m.fields.String()
 
 
+class NestedSchema(m.Schema):
+    name = m.fields.String()
+
+
+class ParentAllowNoneTrueSchema(m.Schema):
+    data = m.fields.List(m.fields.Nested(NestedSchema), allow_none=True)
+
+
+class ParentAllowNoneFalseSchema(m.Schema):
+    data = m.fields.List(m.fields.Nested(NestedSchema))
+
+
 class DefaultResponseSchema(
     m.Schema
 ):  # DEFAULT_RESPONSE = {"uid": "0", "name": "I'm the default for testing!"}
@@ -882,3 +894,39 @@ class RebarTest(unittest.TestCase):
         app = create_rebar_app(rebar)
         resp = app.test_client().get(path="/async")
         self.assertEqual(resp.status_code, 200)
+
+    def test_nested_list_allow_none_ref_issue(self):
+        rebar = Rebar()
+        registry = rebar.create_handler_registry()
+
+        register_endpoint(
+            registry=registry,
+            method="POST",
+            path="/nested_list_allow_none_true",
+            response_body_schema=ParentAllowNoneTrueSchema,
+        )
+
+        register_endpoint(
+            registry=registry,
+            method="POST",
+            path="/nested_list_allow_none_false",
+            response_body_schema=ParentAllowNoneFalseSchema,
+        )
+
+        from flask_rebar import SwaggerV3Generator
+
+        swagger = SwaggerV3Generator().generate(registry)
+
+        # Both parent schemas should have refs
+        self.assertEqual(
+            swagger["components"]["schemas"]["ParentAllowNoneFalseSchema"][
+                "properties"
+            ]["data"]["items"]["$ref"],
+            "#/components/schemas/NestedSchema",
+        )
+        self.assertEqual(
+            swagger["components"]["schemas"]["ParentAllowNoneTrueSchema"]["properties"][
+                "data"
+            ]["items"]["$ref"],
+            "#/components/schemas/NestedSchema",
+        )


### PR DESCRIPTION
### Summary

OpenAPI 3.1 removed `nullable: true` and expanded `type` to be either a string or a list of strings. For nullable fields, `type` will be an array that has "null" as a value: `type: ["object", "null"]`.

This PR reproduces and fixes https://github.com/plangrid/flask-rebar/issues/314 by teaching `flatten` to expect either a string or list of strings, allowing it to correctly resolves nested objects into references.