### PR TITLE
Bump version: 3.3.0 -> 3.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 if __name__ == "__main__":
     setup(
         name="flask-rebar",
-        version="3.3.0",
+        version="3.3.1",
         author="Barak Alon",
         author_email="barak.s.alon@gmail.com",
         description="Flask-Rebar combines flask, marshmallow, and swagger for robust REST services.",


### PR DESCRIPTION
This release updates the `flatten` function to expect either strings or a list of strings and correctly resolve the nested objects into references. https://github.com/plangrid/flask-rebar/pull/315 