### PR TITLE
[PJL-10221] handle some edge cases in OpenAPI v3.1 swagger generation

### DIFF
--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -427,7 +427,7 @@ class DictConverter(FieldConverter[m.fields.Dict]):
     @sets_swagger_attr(sw.additional_properties)
     def get_additional_properties(
         self, obj: m.fields.Dict, context: _Context
-    ) -> Union[UNSET, m.fields.Dict]:
+    ) -> Union[Type[UNSET], m.fields.Dict]:
         if obj.value_field:
             return context.convert(obj.value_field, context)
         else:

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -618,9 +618,7 @@ class ContainsOnlyConverter(ValidatorConverter):
     MARSHMALLOW_TYPE = ContainsOnly
 
     @sets_swagger_attr(sw.items)
-    def get_items(
-        self, obj: ContainsOnly, context: _Context
-    ) -> Union[Type[UNSET], m.fields.List]:
+    def get_items(self, obj: ContainsOnly, context: _Context) -> dict[str, Any]:
         return {"type": context.memo["items"]["type"], "enum": obj.choices}
 
 

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -37,6 +37,7 @@ import marshmallow as m
 from marshmallow import Schema
 from marshmallow.validate import Range
 from marshmallow.validate import OneOf
+from marshmallow.validate import ContainsOnly
 from marshmallow.validate import Length
 from marshmallow.validate import Validator
 
@@ -604,6 +605,16 @@ class RangeConverter(ValidatorConverter):
             return UNSET
 
 
+class ContainsOnlyConverter(ValidatorConverter):
+    MARSHMALLOW_TYPE = ContainsOnly
+
+    @sets_swagger_attr(sw.items)
+    def get_items(
+        self, obj: ContainsOnly, context: _Context
+    ) -> Union[Type[UNSET], m.fields.List]:
+        return {"type": context.memo["items"]["type"], "enum": obj.choices}
+
+
 class OneOfConverter(ValidatorConverter):
     MARSHMALLOW_TYPE = OneOf
 
@@ -794,6 +805,7 @@ def _common_converters() -> List[MarshmallowConverter]:
     """Instantiates the converters we use in ALL of the registries below"""
     converters: List[MarshmallowConverter] = [
         BooleanConverter(),
+        ContainsOnlyConverter(),
         DateConverter(),
         DateTimeConverter(),
         FunctionConverter(),

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -618,7 +618,7 @@ class ContainsOnlyConverter(ValidatorConverter):
     MARSHMALLOW_TYPE = ContainsOnly
 
     @sets_swagger_attr(sw.items)
-    def get_items(self, obj: ContainsOnly, context: _Context) -> dict[str, Any]:
+    def get_items(self, obj: ContainsOnly, context: _Context) -> Dict[str, Any]:
         return {"type": context.memo["items"]["type"], "enum": obj.choices}
 
 

--- a/flask_rebar/swagger_generation/marshmallow_to_swagger.py
+++ b/flask_rebar/swagger_generation/marshmallow_to_swagger.py
@@ -424,6 +424,15 @@ class DictConverter(FieldConverter[m.fields.Dict]):
     def get_type(self, obj: m.fields.Dict, context: _Context) -> Union[str, List[str]]:
         return self.null_type_determination(obj, context, sw.object_)
 
+    @sets_swagger_attr(sw.additional_properties)
+    def get_additional_properties(
+        self, obj: m.fields.Dict, context: _Context
+    ) -> Union[UNSET, m.fields.Dict]:
+        if obj.value_field:
+            return context.convert(obj.value_field, context)
+        else:
+            return UNSET
+
 
 class IntegerConverter(FieldConverter[m.fields.Integer]):
     MARSHMALLOW_TYPE = m.fields.Integer

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -195,6 +195,46 @@ class TestConverterRegistry(TestCase):
                 },
             )
 
+    def test_list_enum_openapi_v3(self):
+        for field, result in [
+            (m.fields.Integer(allow_none=True), {"type": ["integer", "null"]}),
+            (
+                QueryParamList(m.fields.Integer(), validate=v.ContainsOnly([1, 2, 3])),
+                {
+                    "type": "array",
+                    "items": {"type": "integer", "enum": [1, 2, 3]},
+                    "explode": True,
+                },
+            ),
+            (
+                CommaSeparatedList(
+                    m.fields.String(), validate=v.ContainsOnly(["a", "b", "c"])
+                ),
+                {
+                    "type": "array",
+                    "items": {"type": "string", "enum": ["a", "b", "c"]},
+                    "style": "form",
+                    "explode": False,
+                },
+            ),
+        ]:
+
+            class Foo(m.Schema):
+                a = field
+
+            schema = Foo()
+            json_schema = self.registry.convert(schema, openapi_version=3)
+
+            self.assertEqual(
+                json_schema,
+                {
+                    "additionalProperties": False,
+                    "type": "object",
+                    "title": "Foo",
+                    "properties": {"a": result},
+                },
+            )
+
     def test_data_key(self):
         registry = ConverterRegistry()
         registry.register_types(ALL_CONVERTERS)

--- a/tests/swagger_generation/test_marshmallow_to_swagger.py
+++ b/tests/swagger_generation/test_marshmallow_to_swagger.py
@@ -244,9 +244,7 @@ class TestConverterRegistry(TestCase):
             ),
             (
                 m.fields.Dict(
-                    keys=m.fields.String(),
                     values=m.fields.Integer(),
-                    dump_default={"a": 1},
                 ),
                 {
                     "type": "object",
@@ -255,7 +253,7 @@ class TestConverterRegistry(TestCase):
             ),
             (
                 m.fields.Dict(
-                    keys=m.fields.String(validate=v.OneOf("a", "b", "c")),
+                    keys=m.fields.String(),
                     values=m.fields.String(),
                 ),
                 {


### PR DESCRIPTION
**Change 1**

Right now, ContainsOnly validators are being handled identically to OneOf validators. This is because, in Marshmallow, ContainsOnly is a subclass of OneOf. However, this isn't actually correct because the logic is different -

* ContainsOnly: *Validator which succeeds **if value is a sequence** and **each element in the sequence** is also in the sequence passed as choices.*
* OneOf: Validator which succeeds if **value** is a member of choices.

I added a separate validator to handle ContainsOnly and validated that it produces the expected output against one of our repos (PADD). You can see in the below screenshot that we were incorrectly specifying the `enum:` parameter at the level of the `value` itself (which causes an error if you run this against an OpenAPI validator, because you're comparing an array to a string) when the `enum:` should actually be at under the `items:`.

<img width="225" alt="Screenshot 2024-10-02 at 8 58 13" src="https://github.com/user-attachments/assets/b912e493-b72b-47f8-9704-ea05cc429265">

**Change 2**

In OpenAPI 3 https://swagger.io/docs/specification/v3_0/data-models/dictionaries/ we are able to specify the allowed types of dictionary values (keys must always be strings so there is no need to specify their type) in the swagger file. The corresponding marshmallow param would be `values`. I added logic to factor in any schema passed into the `values` param and generate it in the swagger file. I also tested this on PADD and got expected results.