### PR TITLE
fix type hint

### DIFF
--- a/flask_rebar/rebar.py
+++ b/flask_rebar/rebar.py
@@ -586,8 +586,8 @@ class HandlerRegistry:
         query_string_schema: Optional[Schema] = None,
         request_body_schema: Optional[Schema] = None,
         headers_schema: Union[Type[USE_DEFAULT], Schema] = USE_DEFAULT,
-        authenticators: Union[
-            Type[USE_DEFAULT], List[Authenticator], Authenticator
+        authenticators: Optional[
+            Union[Type[USE_DEFAULT], List[Authenticator], Authenticator]
         ] = USE_DEFAULT,
         tags: Optional[Sequence[str]] = None,
         mimetype: Union[Type[USE_DEFAULT], str] = USE_DEFAULT,


### PR DESCRIPTION
I got a type warning when setting `authenticators = None` here.  (This has been in our code for years, but type hints were only added to this library relatively recently)

The value is set by default to `USE_DEFAULT` anyway, so I think we should allow the user to configure `None`.